### PR TITLE
build시 서브 모듈의 테스트 코드에서 SpringApplication이 실행되지 않은 오류 수정

### DIFF
--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/OnedayheroApplicationTests.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/OnedayheroApplicationTests.java
@@ -1,9 +1,10 @@
 package com.sixheroes.onedayheroapplication;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootApplication(scanBasePackages = "com.sixheroes")
 class OnedayheroApplicationTests {
 
     @Test

--- a/onedayhero-common/src/test/java/com/sixheroes/onedayherocommon/OnedayheroCommonApplicationTests.java
+++ b/onedayhero-common/src/test/java/com/sixheroes/onedayherocommon/OnedayheroCommonApplicationTests.java
@@ -1,9 +1,10 @@
 package com.sixheroes.onedayherocommon;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootApplication(scanBasePackages = "com.sixheroes")
 class OnedayheroCommonApplicationTests {
 
     @Test

--- a/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/OnedayheroDomainApplicationTests.java
+++ b/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/OnedayheroDomainApplicationTests.java
@@ -1,9 +1,10 @@
 package com.sixheroes.onedayherodomain;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootApplication(scanBasePackages = "com.sixheroes")
 class OnedayheroDomainApplicationTests {
 
     @Test

--- a/onedayhero-infra-querydsl/src/test/java/com/sixheroes/onedayheroinfraquerydsl/OnedayheroInfraQuerydslApplicationTests.java
+++ b/onedayhero-infra-querydsl/src/test/java/com/sixheroes/onedayheroinfraquerydsl/OnedayheroInfraQuerydslApplicationTests.java
@@ -1,9 +1,10 @@
 package com.sixheroes.onedayheroinfraquerydsl;
 
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootTest
+@SpringBootApplication(scanBasePackages = "com.sixheroes")
 class OnedayheroInfraQuerydslApplicationTests {
 
     @Test


### PR DESCRIPTION
## 🖊️ 1. Changes
- submodule은 실행하기 위한 Main(`@SpringBootApplication`)이 없어서, spring bean 주입 에러가 발생합니다.
- 이에 따라, `@SpringBootApplication` 을 각 모듈의 테스트 코드에 작성해주고, scanBasePackages를 지정하였습니다.
- 이후, Application 영역에서는 `@EntityScan` 과 `@EnableJpaRepositories` 의 basePackages를 추가해주어야 할 수 있습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans 
