### PR TITLE
[SIX-6] 도메인 구현

### DIFF
--- a/.idea/.gitignore
+++ b/.idea/.gitignore
@@ -1,0 +1,8 @@
+# Default ignored files
+/shelf/
+/workspace.xml
+# Editor-based HTTP Client requests
+/httpRequests/
+# Datasource local storage ignored files
+/dataSources/
+/dataSources.local.xml

--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+onedayhero

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/OnedayheroApiApplication.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/OnedayheroApiApplication.java
@@ -1,4 +1,4 @@
-package com.sixheroes;
+package com.sixheroes.onedayheroapi;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;

--- a/onedayhero-domain/build.gradle
+++ b/onedayhero-domain/build.gradle
@@ -1,6 +1,8 @@
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
     api 'org.hibernate:hibernate-spatial:6.2.13.Final'
+    api 'io.hypersistence:hypersistence-utils-hibernate-62:3.6.0'
+    api 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations'
     api 'com.h2database:h2'
 }
 

--- a/onedayhero-domain/build.gradle
+++ b/onedayhero-domain/build.gradle
@@ -1,5 +1,6 @@
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
+    api 'org.hibernate:hibernate-spatial:6.2.13.Final'
     api 'com.h2database:h2'
 }
 

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/achievement/Achievement.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/achievement/Achievement.java
@@ -1,0 +1,20 @@
+package com.sixheroes.onedayherodomain.achievement;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "achievements")
+@Entity
+public class Achievement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/achievement/UserAchievement.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/achievement/UserAchievement.java
@@ -1,0 +1,23 @@
+package com.sixheroes.onedayherodomain.achievement;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_achievements")
+@Entity
+public class UserAchievement {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "achievement_id", nullable = false)
+    private Long achievementId;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/achievement/repository/AchievementRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/achievement/repository/AchievementRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.achievement.repository;
+
+import com.sixheroes.onedayherodomain.achievement.Achievement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AchievementRepository extends JpaRepository<Achievement, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/achievement/repository/UserAchievementRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/achievement/repository/UserAchievementRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.achievement.repository;
+
+import com.sixheroes.onedayherodomain.achievement.UserAchievement;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserAchievementRepository extends JpaRepository<UserAchievement, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
@@ -1,0 +1,57 @@
+package com.sixheroes.onedayherodomain.mission;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.geo.Point;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "missions")
+@Entity
+public class Mission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "citizen_id", nullable = false)
+    private Long citizenId;
+
+    @Column(name = "category_id", nullable = false)
+    private Long categoryId;
+
+    @Column(name = "region_id", nullable = false)
+    private Long regionId;
+
+    @Column(name = "location", nullable = false)
+    private Point location;
+
+    @Lob
+    @Column(name = "content", nullable = false)
+    private String content;
+
+    @Column(name = "mission_date", nullable = false)
+    private LocalDate missionDate;
+
+    @Column(name = "start_time", nullable = false)
+    private LocalTime startTime;
+
+    @Column(name = "end_time", nullable = false)
+    private LocalTime endTime;
+
+    @Column(name = "price", nullable = false)
+    private Long price;
+
+    @Column(name = "deadline_time", nullable = false)
+    private LocalTime deadlineTime;
+
+    @Column(name = "is_match", nullable = false)
+    private boolean isMatch;
+
+
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
@@ -51,7 +51,5 @@ public class Mission {
     private LocalTime deadlineTime;
 
     @Column(name = "is_match", nullable = false)
-    private boolean isMatch;
-
-
+    private Boolean isMatch;
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategory.java
@@ -1,0 +1,20 @@
+package com.sixheroes.onedayherodomain.mission;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mission_category")
+@Entity
+public class MissionCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name")
+    private String name;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategory.java
@@ -15,6 +15,6 @@ public class MissionCategory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "name")
+    @Column(name = "name", nullable = false)
     private String name;
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionImage.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionImage.java
@@ -19,11 +19,11 @@ public class MissionImage {
     private Long mission_id;
 
     @Column(name = "original_name", nullable = false)
-    private String original_name;
+    private String originalName;
 
     @Column(name = "unique_name", nullable = false)
-    private String unique_name;
+    private String uniqueName;
 
-    @Column(name = "paths", nullable = false)
+    @Column(name = "path", nullable = false)
     private String path;
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionImage.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionImage.java
@@ -1,0 +1,29 @@
+package com.sixheroes.onedayherodomain.mission;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mission_images")
+@Entity
+public class MissionImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mission_id", nullable = false)
+    private Long mission_id;
+
+    @Column(name = "original_name", nullable = false)
+    private String original_name;
+
+    @Column(name = "unique_name", nullable = false)
+    private String unique_name;
+
+    @Column(name = "paths", nullable = false)
+    private String path;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionImage.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionImage.java
@@ -16,7 +16,7 @@ public class MissionImage {
     private Long id;
 
     @Column(name = "mission_id", nullable = false)
-    private Long mission_id;
+    private Long missionId;
 
     @Column(name = "original_name", nullable = false)
     private String originalName;

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/MissionCategoryRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/MissionCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.mission.repository;
+
+import com.sixheroes.onedayherodomain.mission.MissionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionCategoryRepository extends JpaRepository<MissionCategory, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/MissionImageRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/MissionImageRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.mission.repository;
+
+import com.sixheroes.onedayherodomain.mission.MissionImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionImageRepository extends JpaRepository<MissionImage, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/MissionRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/MissionRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.mission.repository;
+
+import com.sixheroes.onedayherodomain.mission.Mission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionRepository extends JpaRepository<Mission, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/MissionChatRoom.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/MissionChatRoom.java
@@ -1,0 +1,28 @@
+package com.sixheroes.onedayherodomain.missionchatroom;
+
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mission_chat_rooms")
+@Entity
+public class MissionChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mission_id", nullable = false)
+    private Long missionId;
+
+    @Column(name = "hero_id", nullable = false)
+    private Long heroId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private MissionChatRoomStatus missionChatRoomStatus;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/MissionChatRoomStatus.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/MissionChatRoomStatus.java
@@ -1,0 +1,4 @@
+package com.sixheroes.onedayherodomain.missionchatroom;
+
+public enum MissionChatRoomStatus {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/repository/MissionChatRoomRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/repository/MissionChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.missionchatroom.repository;
+
+import com.sixheroes.onedayherodomain.missionchatroom.MissionChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionChatRoomRepository extends JpaRepository<MissionChatRoom, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatch.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatch.java
@@ -1,0 +1,27 @@
+package com.sixheroes.onedayherodomain.missionmatch;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mission_matches")
+@Entity
+public class MissionMatch {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mission_id", nullable = false)
+    private Long missionId;
+
+    @Column(name = "hero_id", nullable = false)
+    private Long heroId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private MissionMatchStatus missionMatchStatus;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatchStatus.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatchStatus.java
@@ -1,0 +1,4 @@
+package com.sixheroes.onedayherodomain.missionmatch;
+
+public enum MissionMatchStatus {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/repository/MissionMatchRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/repository/MissionMatchRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.missionmatch.repository;
+
+import com.sixheroes.onedayherodomain.missionmatch.MissionMatch;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionMatchRepository extends JpaRepository<MissionMatch, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionrequest/MissionRequest.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionrequest/MissionRequest.java
@@ -1,0 +1,27 @@
+package com.sixheroes.onedayherodomain.missionrequest;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mission_requests")
+@Entity
+public class MissionRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mission_id", nullable = false)
+    private Long missionId;
+
+    @Column(name = "hero_id", nullable = false)
+    private Long heroId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private MissionRequestStatus missionRequestStatus;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionrequest/MissionRequestStatus.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionrequest/MissionRequestStatus.java
@@ -1,0 +1,4 @@
+package com.sixheroes.onedayherodomain.missionrequest;
+
+public enum MissionRequestStatus {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionrequest/repository/MissionRequestRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionrequest/repository/MissionRequestRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.missionrequest.repository;
+
+import com.sixheroes.onedayherodomain.missionrequest.MissionRequest;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionRequestRepository extends JpaRepository<MissionRequest, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/Review.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/Review.java
@@ -1,0 +1,24 @@
+package com.sixheroes.onedayherodomain.missionreview;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "reviews")
+@Entity
+public class Review {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "star_id", nullable = false)
+    private Long starId;
+
+    @Lob
+    @Column(name = "content", nullable = false)
+    private String content;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/ReviewImage.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/ReviewImage.java
@@ -1,0 +1,29 @@
+package com.sixheroes.onedayherodomain.missionreview;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "review_images")
+@Entity
+public class ReviewImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "review_id")
+    private Long reviewId;
+
+    @Column(name = "original_name", nullable = false)
+    private String original_name;
+
+    @Column(name = "unique_name", nullable = false)
+    private String unique_name;
+
+    @Column(name = "paths", nullable = false)
+    private String path;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/ReviewImage.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/ReviewImage.java
@@ -15,15 +15,15 @@ public class ReviewImage {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "review_id")
+    @Column(name = "review_id", nullable = false)
     private Long reviewId;
 
     @Column(name = "original_name", nullable = false)
-    private String original_name;
+    private String originalName;
 
     @Column(name = "unique_name", nullable = false)
-    private String unique_name;
+    private String uniqueName;
 
-    @Column(name = "paths", nullable = false)
+    @Column(name = "path", nullable = false)
     private String path;
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/ReviewRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/ReviewRepository.java
@@ -1,0 +1,6 @@
+package com.sixheroes.onedayherodomain.missionreview;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewRepository extends JpaRepository<Review, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/repository/ReviewImageRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/repository/ReviewImageRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.missionreview.repository;
+
+import com.sixheroes.onedayherodomain.missionreview.ReviewImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReviewImageRepository extends JpaRepository<ReviewImage, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/repository/ReviewRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionreview/repository/ReviewRepository.java
@@ -1,5 +1,6 @@
-package com.sixheroes.onedayherodomain.missionreview;
+package com.sixheroes.onedayherodomain.missionreview.repository;
 
+import com.sixheroes.onedayherodomain.missionreview.Review;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ReviewRepository extends JpaRepository<Review, Long> {

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/region/Region.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/region/Region.java
@@ -1,0 +1,26 @@
+package com.sixheroes.onedayherodomain.region;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "regions")
+@Entity
+public class Region {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "si", nullable = false)
+    private String si;
+
+    @Column(name = "gu", nullable = false)
+    private String gu;
+
+    @Column(name = "dong", nullable = false)
+    private String dong;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/region/UserRegion.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/region/UserRegion.java
@@ -1,0 +1,23 @@
+package com.sixheroes.onedayherodomain.region;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_regions")
+@Entity
+public class UserRegion {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "region_id", nullable = false)
+    private Long regionId;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/region/repository/RegionRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/region/repository/RegionRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.region.repository;
+
+import com.sixheroes.onedayherodomain.region.Region;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface RegionRepository extends JpaRepository<Region, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/region/repository/UserRegionRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/region/repository/UserRegionRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.region.repository;
+
+import com.sixheroes.onedayherodomain.region.UserRegion;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRegionRepository extends JpaRepository<UserRegion, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/ReportCategory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/ReportCategory.java
@@ -7,7 +7,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "report_category")
+@Table(name = "report_categories")
 @Entity
 public class ReportCategory {
 

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/ReportCategory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/ReportCategory.java
@@ -1,0 +1,20 @@
+package com.sixheroes.onedayherodomain.report;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "report_category")
+@Entity
+public class ReportCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false)
+    private String name;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/ReportHistory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/ReportHistory.java
@@ -15,16 +15,16 @@ public class ReportHistory {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name = "reporter_id")
+    @Column(name = "reporter_id", nullable = false)
     private Long reporterId;
 
-    @Column(name = "report_category_id")
+    @Column(name = "report_category_id", nullable = false)
     private Long reportCategoryId;
 
-    @Column(name = "reported_id")
+    @Column(name = "reported_id", nullable = false)
     private Long reportedId;
 
     @Lob
-    @Column(name = "content")
+    @Column(name = "content", nullable = false)
     private String content;
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/ReportHistory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/ReportHistory.java
@@ -1,0 +1,30 @@
+package com.sixheroes.onedayherodomain.report;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "report_histories")
+@Entity
+public class ReportHistory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "reporter_id")
+    private Long reporterId;
+
+    @Column(name = "report_category_id")
+    private Long reportCategoryId;
+
+    @Column(name = "reported_id")
+    private Long reportedId;
+
+    @Lob
+    @Column(name = "content")
+    private String content;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/repository/ReportCategoryRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/repository/ReportCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.report.repository;
+
+import com.sixheroes.onedayherodomain.report.ReportCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportCategoryRepository extends JpaRepository<ReportCategory, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/repository/ReportHistoryRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/report/repository/ReportHistoryRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.report.repository;
+
+import com.sixheroes.onedayherodomain.report.ReportHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReportHistoryRepository extends JpaRepository<ReportHistory, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/star/ReviewerType.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/star/ReviewerType.java
@@ -1,0 +1,4 @@
+package com.sixheroes.onedayherodomain.star;
+
+public enum ReviewerType {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/star/Star.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/star/Star.java
@@ -1,0 +1,33 @@
+package com.sixheroes.onedayherodomain.star;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "stars")
+@Entity
+public class Star {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "mission_id", nullable = false)
+    private Long missionId;
+
+    @Column(name = "sender_id", nullable = false)
+    private Long senderId;
+
+    @Column(name = "receiver_id", nullable = false)
+    private Long receiverId;
+
+    @Column(name = "score", nullable = false)
+    private Double score;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "reviewer_type", nullable = false)
+    private ReviewerType reviewerType;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/star/repository/StarRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/star/repository/StarRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.star.repository;
+
+import com.sixheroes.onedayherodomain.star.Star;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StarRepository extends JpaRepository<Star, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/User.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/User.java
@@ -1,0 +1,60 @@
+package com.sixheroes.onedayherodomain.user;
+
+import io.hypersistence.utils.hibernate.type.json.JsonType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.Type;
+
+import java.time.LocalDate;
+import java.util.HashMap;
+import java.util.Map;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "users")
+@Entity
+public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "email", nullable = false)
+    private String email;
+
+    @Column(name = "birth", nullable = false)
+    private LocalDate birth;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "social_type", nullable = false)
+    private UserSocialType userSocialType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "role", nullable = false)
+    private UserRole userRole;
+
+    @Column(name = "introduce", nullable = false)
+    private String introduce;
+
+    @Column(name = "hero_score", nullable = false)
+    private Integer heroScore;
+
+    @Type(JsonType.class)
+    @Column(name = "favorite_date", columnDefinition = "json", nullable = false)
+    private Map<String, Week[]> favoriteDate = new HashMap<>();
+
+    @Column(name = "is_hero_mode", nullable = false)
+    private Boolean isHeroMode;
+
+    @Column(name = "is_active", nullable = false)
+    private Boolean isActive;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserActivityStatistic.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserActivityStatistic.java
@@ -1,0 +1,32 @@
+package com.sixheroes.onedayherodomain.user;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_activity_statistics")
+@Entity
+public class UserActivityStatistic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "complete_count", nullable = false)
+    private Integer completeCount;
+
+    @Column(name = "no_show_count", nullable = false)
+    private Integer noShowCount;
+
+    @Column(name = "give_up_count", nullable = false)
+    private Integer giveUpCount;
+
+    @Column(name = "withdraw_count", nullable = false)
+    private Integer withdrawCount;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserImage.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserImage.java
@@ -1,0 +1,34 @@
+package com.sixheroes.onedayherodomain.user;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_images")
+@Entity
+public class UserImage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "original_name", nullable = false)
+    private String originalName;
+
+    @Column(name = "unique_name", nullable = false)
+    private String uniqueName;
+
+    @Column(name = "path", nullable = false)
+    private String path;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserRole.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserRole.java
@@ -1,0 +1,4 @@
+package com.sixheroes.onedayherodomain.user;
+
+public enum UserRole {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserSocialType.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserSocialType.java
@@ -1,0 +1,4 @@
+package com.sixheroes.onedayherodomain.user;
+
+public enum UserSocialType {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/Week.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/Week.java
@@ -1,0 +1,5 @@
+package com.sixheroes.onedayherodomain.user;
+
+public enum Week {
+    // TODO 요일 상수로 MONDEY, TUESDAY ...
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/repository/UserActivityStatisticRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/repository/UserActivityStatisticRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.user.repository;
+
+import com.sixheroes.onedayherodomain.user.UserActivityStatistic;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserActivityStatisticRepository extends JpaRepository<UserActivityStatistic, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/repository/UserImageRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/repository/UserImageRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.user.repository;
+
+import com.sixheroes.onedayherodomain.user.UserImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserImageRepository extends JpaRepository<UserImage, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/repository/UserRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.user.repository;
+
+import com.sixheroes.onedayherodomain.user.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/usermission/UserMissionCategory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/usermission/UserMissionCategory.java
@@ -1,0 +1,23 @@
+package com.sixheroes.onedayherodomain.usermission;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_mission_categories")
+@Entity
+public class UserMissionCategory {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "mission_category_id", nullable = false)
+    private Long missionCategoryId;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/usermission/repository/UserMissionCategoryRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/usermission/repository/UserMissionCategoryRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.usermission.repository;
+
+import com.sixheroes.onedayherodomain.usermission.UserMissionCategory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserMissionCategoryRepository extends JpaRepository<UserMissionCategory, Long> {
+}


### PR DESCRIPTION
## 🖊️ 1. Changes
- 미션 도메인을 구현하였습니다.
- R-Index를 사용하기 위해 MySQL에서 지원하는 Point 컬럼을 사용 할 필요가 있었습니다. 이를 위해서 
- `'org.hibernate:hibernate-spatial:6.2.13.Final'` hibernate 구현체에 공간데이터를 다룰 수 있는 컬럼을 제공해주는 라이브러리 의존성을 추가해주었습니다.
- erd에서 latitude, longitude로 분리했던 부분을 location이라는 이름 하나로 합쳤습니다. 받아서 생성시에는 다음과 같이 가능합니다. `new Point(latitude, longitude);`
- erd에서 미션 수행 날짜에 대한 필드가 누락되어 erd에 반영하고 추가하였습니다.
- domain의 패키지 마지막 depth가 누락되어 임의로 추가하였습니다. api에도 하나의 패키지 depth가 누락됨을 볼 수 있었습니다. 후에 추가해야 할 것 같습니다
---
- 각 도메인의 Repository를 추가하기로 했었는데 누락되어 추가하여 반영하였습니다.
- 유저 활동 통계는 따로 유저 통계 패키지를 만들지 않고 User 패키지에 포함하였습니다. 동일한 Aggregate 라고 판단했습니다

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer
- 원래는 스토리마다 브랜치를 만들면서 Epic 브랜치에 머지를 하고, Epic 기능이 완성되면 develop에 merge를 하는 형태를 하기로 했었는데, 위 이슈는 Epic 아래에 서브태스크들만 나열했기에 바로 develop으로 머지하도록 했습니다.

## ✅ 5. Plans
- [X] api 패키지의 depth가 누락된 부분 변경
- [X] 미션 이미지 도메인 구현
- [x] 미션 매칭 도메인 구현
- [x] 미션 카테고리 도메인 구현
- [x] 미션 요청 도메인 구현
- [x] 미션 챗 룸 도메인 구현
- [x] 별점 도메인 구현
- [x] 리뷰 도메인 구현
- [x] 리뷰 이미지 도메인 구현
- [x] 유저 활동 통계 도메인 구현
- [x] 유저 신고 기록 도메인 구현
- [x] 신고 카테고리 도메인 구현
- [x] 유저 미션 카테고리 도메인 구현
- [x] 유저 지역 도메인 구현
- [x] 지역 도메인 구현
- [x] 업적 도메인 구현
- [x] 유저 업적 도메인 구현    