### PR TITLE
[SIX-22] 공통 응답 객체를 생성하는 기능 구현

### DIFF
--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/handler/GlobalExceptionHandler.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/handler/GlobalExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.sixheroes.onedayheroapi.global.handler;
+
+import com.sixheroes.onedayheroapi.global.response.ErrorCode;
+import com.sixheroes.onedayheroapi.global.response.ErrorResponse;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.validation.BindException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(value = Exception.class)
+    public ErrorResponse handleException(Exception exception) {
+        log.error("Error occurred", exception);
+        var errorCode = ErrorCode.S_001;
+        return ErrorResponse.from(errorCode);
+    }
+
+    @ExceptionHandler(value = RuntimeException.class)
+    public ErrorResponse handleRuntimeException(RuntimeException exception) {
+        var errorCode = ErrorCode.valueOf(exception.getMessage());
+        return ErrorResponse.from(errorCode);
+    }
+
+    @ExceptionHandler(value = BindException.class)
+    public ErrorResponse handleBindException(BindException exception) {
+        var errorCode = ErrorCode.T_001;
+        return ErrorResponse.from(errorCode, exception);
+    }
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ApiResponse.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ApiResponse.java
@@ -1,0 +1,28 @@
+package com.sixheroes.onedayheroapi.global.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import org.springframework.http.HttpStatus;
+
+import java.time.LocalDateTime;
+
+public record ApiResponse<T>(
+        int status,
+
+        T data,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime serverDateTime
+) {
+
+    public ApiResponse<T> ok(T data) {
+        return new ApiResponse<>(HttpStatus.OK.value(), data, LocalDateTime.now());
+    }
+
+    public ApiResponse<T> created(T data) {
+        return new ApiResponse<>(HttpStatus.CREATED.value(), data, LocalDateTime.now());
+    }
+
+    public ApiResponse<T> noContent(T data) {
+        return new ApiResponse<>(HttpStatus.NO_CONTENT.value(), data, LocalDateTime.now());
+    }
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ErrorCode.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ErrorCode.java
@@ -1,0 +1,20 @@
+package com.sixheroes.onedayheroapi.global.response;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * <pre><b>code</b>는 프론트와 정한 에러 코드를 넣어준다.</pre>
+ * <pre><b>status</b>는 값에 따라 백엔드에서 넣어준다.</pre>
+ * <pre><b>message</b>는 프론트와 협의해서 정한 에러 메시지를 넣어준다.</pre>
+ */
+@Getter
+@RequiredArgsConstructor
+public enum ErrorCode {
+    T_001(400, "입력 값에서 오류가 발생했습니다."),
+
+    S_001(500, "서버에서 알 수 없는 오류가 발생했습니다.");
+
+    private final int status;
+    private final String message;
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ErrorResponse.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ErrorResponse.java
@@ -1,0 +1,66 @@
+package com.sixheroes.onedayheroapi.global.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.Builder;
+import org.springframework.validation.BindException;
+import org.springframework.validation.FieldError;
+
+import java.util.List;
+
+/**
+ * @param code    는 프론트와 정한 ErrorCode를 의미한다.
+ * @param status  는 HttpStatusCode의 value를 의미한다. <b>EX) 200</b>
+ * @param message 는 Error에 대한 메시지를 의미한다.
+ * @param errors  는 BindException에서 발생 할 수 있는 입력 에러에 해당한다.
+ */
+@Builder
+public record ErrorResponse(
+        String code,
+
+        int status,
+
+        String message,
+
+        @JsonInclude(JsonInclude.Include.NON_EMPTY)
+        List<ValidationError> errors
+) {
+
+    public static ErrorResponse from(final ErrorCode errorCode) {
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .status(errorCode.getStatus())
+                .message(errorCode.getMessage())
+                .build();
+    }
+
+    public static ErrorResponse from(
+            final ErrorCode errorCode,
+            final BindException e
+    ) {
+        return ErrorResponse.builder()
+                .code(errorCode.name())
+                .status(errorCode.getStatus())
+                .message(errorCode.getMessage())
+                .errors(ValidationError.of(e.getBindingResult().getFieldErrors()))
+                .build();
+    }
+
+    @Builder
+    public record ValidationError(
+            String field,
+            String message
+    ) {
+        private static ValidationError from(final FieldError fieldError) {
+            return ValidationError.builder()
+                    .field(fieldError.getField())
+                    .message(fieldError.getDefaultMessage())
+                    .build();
+        }
+
+        private static List<ValidationError> of(final List<FieldError> fieldErrors) {
+            return fieldErrors.stream()
+                    .map(ValidationError::from)
+                    .toList();
+        }
+    }
+}


### PR DESCRIPTION
## 🖊️ 1. Changes
- ErrorResponse에는 `BindException` 에서 발생하는 ValidationError를 가지고 있습니다. 해당 반환 값은 존재 할 시에만 Json으로 반환됩니다.
- Exception 반환 시에는 기본적으로 기본 예외를 반환하도록 합니다. 그리고 Message에는 ErrorCode의 code명이 들어갑니다.
```java
throw new RuntimeException(ErrorCode.E_001.name());
```
- ApiResponse는 자주 사용하는 것에 대해서 설정하였고, `Asia/Seoul` 에서만 동작하기때문에 포맷팅을 따로 정하였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans
- [x] - 프론트와 협의 후 컨펌이 되면 머지하도록 하겠습니다.
