### PR TITLE
[SIX-35] ERD에 맞게 엔티티 추가

### DIFF
--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/bookmark/UserBookMarkMission.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/bookmark/UserBookMarkMission.java
@@ -1,0 +1,28 @@
+package com.sixheroes.onedayherodomain.bookmark;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_bookmark_missions")
+@Entity
+public class UserBookMarkMission {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "mission_id", nullable = false)
+    private Long missionId;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/bookmark/repository/UserBookMarkMissionRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/bookmark/repository/UserBookMarkMissionRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.bookmark.repository;
+
+import com.sixheroes.onedayherodomain.bookmark.UserBookMarkMission;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserBookMarkMissionRepository extends JpaRepository<UserBookMarkMission, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionapproval/MissionApproval.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionapproval/MissionApproval.java
@@ -1,0 +1,37 @@
+package com.sixheroes.onedayherodomain.missionapproval;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "mission_approvals")
+@Entity
+public class MissionApproval {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "citizen_id", nullable = false)
+    private Long citizenId;
+
+    @Column(name = "mission_id", nullable = false)
+    private Long missionId;
+
+    @Column(name = "hero_id", nullable = false)
+    private Long heroId;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false)
+    private MissionApprovalStatus missionApprovalStatus;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionapproval/MissionApprovalStatus.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionapproval/MissionApprovalStatus.java
@@ -1,0 +1,4 @@
+package com.sixheroes.onedayherodomain.missionapproval;
+
+public enum MissionApprovalStatus {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionapproval/repository/MissionApprovalRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionapproval/repository/MissionApprovalRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.missionapproval.repository;
+
+import com.sixheroes.onedayherodomain.missionapproval.MissionApproval;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MissionApprovalRepository extends JpaRepository<MissionApproval, Long> {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/UserMissionChatRoom.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/UserMissionChatRoom.java
@@ -1,0 +1,28 @@
+package com.sixheroes.onedayherodomain.missionchatroom;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "user_mission_chat_rooms")
+@Entity
+public class UserMissionChatRoom {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    @Column(name = "mission_chat_room_id", nullable = false)
+    private Long missionChatRoomId;
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/UserMissionChatRoom.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/UserMissionChatRoom.java
@@ -25,4 +25,7 @@ public class UserMissionChatRoom {
 
     @Column(name = "mission_chat_room_id", nullable = false)
     private Long missionChatRoomId;
+
+    @Column(name = "is_joined", nullable = false)
+    private Boolean isJoined;
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/repository/UserMissionChatRoomRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/repository/UserMissionChatRoomRepository.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain.missionchatroom.repository;
+
+import com.sixheroes.onedayherodomain.missionchatroom.UserMissionChatRoom;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserMissionChatRoomRepository extends JpaRepository<UserMissionChatRoom, Long> {
+}


### PR DESCRIPTION
## 🖊️ 1. Changes

- 유저 참여 채팅방, UserMissionChatRoom 도메인 구현 및 Repository 생성했습니다.
- 찜한 미션, UserBookMarkMission 도메인 구현 및 Repository 생성했습니다.
- 미션 승인 요청, MissionApproval 도메인 구현 및 Repository 생성했습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans
- [ ] - base entity 추가되면 상속하기
