### PR TITLE
[SIX-38] ErrorCode Enum을 common 모듈로 이동

### DIFF
--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/handler/GlobalExceptionHandler.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/handler/GlobalExceptionHandler.java
@@ -1,7 +1,7 @@
 package com.sixheroes.onedayheroapi.global.handler;
 
-import com.sixheroes.onedayheroapi.global.response.ErrorCode;
 import com.sixheroes.onedayheroapi.global.response.ErrorResponse;
+import com.sixheroes.onedayherocommon.error.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ApiResponse.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ApiResponse.java
@@ -14,15 +14,15 @@ public record ApiResponse<T>(
         LocalDateTime serverDateTime
 ) {
 
-    public ApiResponse<T> ok(T data) {
+    public static <T> ApiResponse<T> ok(T data) {
         return new ApiResponse<>(HttpStatus.OK.value(), data, LocalDateTime.now());
     }
 
-    public ApiResponse<T> created(T data) {
+    public static <T> ApiResponse<T> created(T data) {
         return new ApiResponse<>(HttpStatus.CREATED.value(), data, LocalDateTime.now());
     }
 
-    public ApiResponse<T> noContent(T data) {
+    public static <T> ApiResponse<T> noContent(T data) {
         return new ApiResponse<>(HttpStatus.NO_CONTENT.value(), data, LocalDateTime.now());
     }
 }

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ErrorResponse.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ErrorResponse.java
@@ -1,6 +1,7 @@
 package com.sixheroes.onedayheroapi.global.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.sixheroes.onedayherocommon.error.ErrorCode;
 import lombok.Builder;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;

--- a/onedayhero-common/src/main/java/com/sixheroes/onedayherocommon/error/ErrorCode.java
+++ b/onedayhero-common/src/main/java/com/sixheroes/onedayherocommon/error/ErrorCode.java
@@ -1,4 +1,4 @@
-package com.sixheroes.onedayheroapi.global.response;
+package com.sixheroes.onedayherocommon.error;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;


### PR DESCRIPTION
## 🖊️ 1. Changes
- ErrorCode Enum을 api 모듈에서 common 모듈로 이동하였습니다.
- ErrorCode는 domain 검증, application 검증 다양한 곳에서 예외를 만들 때 사용 될 수 있기 때문입니다.
- ErrorCode의 패키지는 error를 담아둔다는 명시적으로 error 패키지에 두었습니다.
---
- ApiResponse에서 응답 객체 생성에 대해 정적 메서드 패턴으로 활용 할 수 있도록 static 필드를 추가하였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- 코드 작성 시 좀만 더 신경써보겠습니다 😅

## ✅ 5. Plans
