### PR TITLE
[SIX-50] basePackage 변경으로 인한 scanBase 제거 및 통합 테스트 클래스 추가

### DIFF
--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/IntegrationApplicationTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/IntegrationApplicationTest.java
@@ -1,0 +1,8 @@
+package com.sixheroes.onedayheroapplication;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public abstract class IntegrationApplicationTest {
+
+}

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/OnedayheroApplicationTests.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/OnedayheroApplicationTests.java
@@ -2,9 +2,8 @@ package com.sixheroes.onedayheroapplication;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootApplication(scanBasePackages = "com.sixheroes")
+@SpringBootApplication
 class OnedayheroApplicationTests {
 
     @Test

--- a/onedayhero-common/src/test/java/com/sixheroes/onedayherocommon/OnedayheroCommonApplicationTests.java
+++ b/onedayhero-common/src/test/java/com/sixheroes/onedayherocommon/OnedayheroCommonApplicationTests.java
@@ -2,9 +2,8 @@ package com.sixheroes.onedayherocommon;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootApplication(scanBasePackages = "com.sixheroes")
+@SpringBootApplication
 class OnedayheroCommonApplicationTests {
 
     @Test

--- a/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/IntegrationRepositoryTest.java
+++ b/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/IntegrationRepositoryTest.java
@@ -1,0 +1,7 @@
+package com.sixheroes.onedayherodomain;
+
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+public abstract class IntegrationRepositoryTest {
+}

--- a/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/OnedayheroDomainApplicationTests.java
+++ b/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/OnedayheroDomainApplicationTests.java
@@ -2,9 +2,8 @@ package com.sixheroes.onedayherodomain;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.test.context.SpringBootTest;
 
-@SpringBootApplication(scanBasePackages = "com.sixheroes")
+@SpringBootApplication
 class OnedayheroDomainApplicationTests {
 
     @Test


### PR DESCRIPTION
## 🖊️ 1. Changes
- 기존의 메인 테스트에서 `scanBasePackage`의 값을 임의로 지정했던 부분을 MainApplication 의 Root 위치가 변경되면서 사용하지 않아도 되므로 해당 값들을 제거하였습니다.
---
- Applicaiton 테스트 및 Repository 테스트를 위한 통합 테스트 클래스를 만들어두었습니다. ex) `IntegrationApplicationTest`, `IntegrationRepositoryTest`
- 두 개의 추상 클래스를 보면 `@SpringBootTest` 만 있고, 그 외에는 없는 것을 볼 수 있습니다.
- 스프링의 테스트 서버는 `@SpringBootTest`, `@DataJpaTest`, `@WebMvcTest`, `@JdbcTest` 등등 스프링 부트가 실행 될 가능 성이 있는 애노테이션이 달린 클래스에는 매번 스프링 서버가 다시 실행됩니다. 다시 실행된다는 것은 ApplicationContext를 다시 초기화 할 필요가 있다는 것과 동일합니다.
- 하지만, 만들어 둔 추상 클래스를 상속한다면 모두 동일한 테스트 서버에서 실행되고 다시 테스트 서버를 띄울일이 없기 때문에, 테스트 속도가 대폭적으로 향상됩니다.
- `@DataJpaTest` 를 사용하는 이유도 Spring Data Jpa와 연관되지 않은 빈들은 주입하지 않기 위해 사용하지만, `@Transactional` 에 종속된다는 문제가 있습니다. 하나의 서버에서 모든 테스트가 돌아간다면 초기 빈 주입에 대한 속도는 큰 차이가 없을 것으로 판단되어 `@SpringBootTest`로 지정하였습니다. 
- 위를 이유로, ApplicationTest 및 RepositoryTest가 필요하다면 해당 통합 테스트 추상 클래스를 상속받아서 테스트하시면 될 것 같습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- 다음과 같은 질문이 예상됩니다. **Q. `@WebMvcTest` 를 위한 테스트를 위한 통합 테스트 클래스는 없나요?**
  - A. 물론 만들 수 있습니다. 하지만 WebMvcTest에는 Controller 클래스가 추가로 value 값으로 들어가주어야합니다. 이는 충돌이 야기될 가능성이 있어서 추가하지 않았습니다. `만약, 충돌이 나도 괜찮으니 WebMvcTest 또한 테스트 시간이 너무 오래걸리는 것 같아요!` 라는 얘기가 나오면 그때는 conflict를 해결하면서 하나의 통합 테스트 클래스를 사용해도 괜찮을 것 같습니다.

## ✅ 5. Plans

## 🙌 6. Checklist
- [X] - 통합 테스트를 수행해보셨나요?
- [X] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [X] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
