### PR TITLE
[SIX-62] Restdocs 관련 설정을 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,27 +47,6 @@ configurations {
     }
 }
 
-project(':onedayhero-api') {
-    dependencies {
-        compileOnly project(':onedayhero-application')
-        compileOnly project(':onedayhero-common')
-    }
-}
-
-project(':onedayhero-application') {
-    dependencies {
-        compileOnly project(':onedayhero-domain')
-        compileOnly project(':onedayhero-infra-querydsl')
-        compileOnly project(':onedayhero-common')
-    }
-}
-
-project(':onedayhero-domain') {
-    dependencies {
-        compileOnly project(':onedayhero-common')
-    }
-}
-
 bootJar.enabled = false
 
 tasks.named('test') {

--- a/onedayhero-api/build.gradle
+++ b/onedayhero-api/build.gradle
@@ -1,9 +1,50 @@
+plugins {
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
+}
+
+configurations {
+    asciidoctorExt
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation project(':onedayhero-application')
+
+    // RESTDOCS
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// 전역 변수 설정
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+
+    // 특정 파일만 html로 생성
+    sources {
+        include("**/index.adoc")
+    }
+
+    baseDirFollowsSourceFile() // 다른 adoc 파일 include 시 경로를 baseDir로 맞춘다.
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }

--- a/onedayhero-api/build.gradle
+++ b/onedayhero-api/build.gradle
@@ -9,6 +9,9 @@ configurations {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
+    
+    implementation project(':onedayhero-common')
     implementation project(':onedayhero-application')
 
     // RESTDOCS

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
@@ -1,0 +1,35 @@
+package com.sixheroes.onedayheroapi.docs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sixheroes.onedayheroapi.global.handler.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsSupport {
+
+    protected MockMvc mockMvc;
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setup(RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(setController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+    }
+
+    protected abstract Object setController();
+}

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sixheroes.onedayheroapi.global.handler.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
@@ -28,6 +29,7 @@ public abstract class RestDocsSupport {
                         .operationPreprocessors()
                         .withRequestDefaults(prettyPrint())
                         .withResponseDefaults(prettyPrint()))
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .build();
     }
 

--- a/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,14 @@
+==== Request Fields
+|===
+|path|type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,14 @@
+==== Response Fields
+|===
+|path|type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/onedayhero-application/build.gradle
+++ b/onedayhero-application/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':onedayhero-common')
     implementation project(':onedayhero-domain')
     implementation project(':onedayhero-infra-querydsl')
 }


### PR DESCRIPTION
## 🖊️ 1. Changes
- RESTDOCS 를 수행하기 위한 설정을 추가하였습니다.
- RESTDOCS의 초기 설정을 할 때에는 두 가지 선택사항이 있었습니다.

## 1️⃣ 스프링 부트를 띄워야 하는 설정
```java
@BeforeEach
void setUp(
        WebApplicationContext webApplicationContext,
        RestDocumentationContextProvider provider
) {
        this.mockMvc = MockMvcBuilders.webAppContextSetup(webApplicationContext)
                .apply(MockMvcRestDocumentation.documentationConfiguration(provider))
                .build();
}
```
## 2️⃣ 스프링 부트를 띄워주지 않는 설정
```java
@BeforeEach
    void setup(RestDocumentationContextProvider provider) {
        this.mockMvc = MockMvcBuilders.standaloneSetup(setController())
                .apply(MockMvcRestDocumentation.documentationConfiguration(provider)
                .build();
    }
```
- RESTDOCS 문서를 만들기 위해서 스프링 부트를 새로 띄우면 테스트하는데 필요한 테스트 실행 시간이라는 비용이 현저히 높아질 것 같다고 판단하여 스프링 부트를 띄우지 않는 설정 파일을 만들어주었습니다.
- 다만 스프링을 띄워주지 않는다면 컨트롤러를 직접 주입을 해주어야하는데, 이는 템플릿 메서드 패턴을 통해서 해결하였습니다.

```java
protected abstract Object setController();
```
- 위의 standaloneSetup에서 주입됩니다.
- 실제, 설정파일에서는 request, response의 json이 이쁘게 보이도록 하는 설정과 언어 규격등을 통일하였습니다.
---
1️⃣ Issue Resolve
- 1번 이슈를 api가 spring-data-jpa 라이브러리를 의존하게 함으로써 해결하였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 이후에 Pageagle 여부도 판단하기 위한 ArgumentsResolver를 추가 할 필요가 있었습니다. 그 과정에서 SpringDataJpa의 PagebleResolver를 사용해야 했는데, api 모듈에서 만들다보니 이를 활용할 수가 없었습니다.  ✅
2. 현재 해당 시점과 제가 미션을 개발하고 있는 시점의 데이터 주입 방식이 달라 build 에서 오류가 발생하였습니다.

- application 모듈의 yml에서 다음과 같은 내용을 주석처리 해주면 해결됩니다.
```bash
  sql:
    init:
      mode: embedded
      data-locations: classpath:sql/data.sql
```

## 😌 4. To Reviewer

- 위와 같은 이슈를 생각하니 저희가 api 모듈에서 Pagable을 받을 상황도 존재 할 것 같은데, 받지 못하는 현상이 있습니다. 따라서 SpringDataJpa를 Root에서 주입해주는건 어떤가요? ✅

## ✅ 5. Plans

## 🙌 6. Checklist
- [X] - 통합 테스트를 수행해보셨나요?
- [X] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [X] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
