### PR TITLE
[SIX-36] 유저는 미션을 생성 할 수 있다.

### DIFF
--- a/onedayhero-application/build.gradle
+++ b/onedayhero-application/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':onedayhero-common')
     implementation project(':onedayhero-domain')
     implementation project(':onedayhero-infra-querydsl')
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCategoryResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCategoryResponse.java
@@ -1,7 +1,9 @@
 package com.sixheroes.onedayheroapplication.mission.response;
 
 import com.sixheroes.onedayherodomain.mission.MissionCategory;
+import lombok.Builder;
 
+@Builder
 public record MissionCategoryResponse(
         Long categoryId,
         String code,

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/IntegrationApplicationTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/IntegrationApplicationTest.java
@@ -1,7 +1,9 @@
 package com.sixheroes.onedayheroapplication;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 public abstract class IntegrationApplicationTest {
 

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
@@ -3,42 +3,28 @@ package com.sixheroes.onedayheroapplication.mission;
 import com.sixheroes.onedayheroapplication.IntegrationApplicationTest;
 import com.sixheroes.onedayheroapplication.mission.request.MissionCreateServiceRequest;
 import com.sixheroes.onedayheroapplication.mission.request.MissionInfoServiceRequest;
-import com.sixheroes.onedayherodomain.mission.MissionCategory;
+import com.sixheroes.onedayheroapplication.mission.response.MissionCategoryResponse;
+import com.sixheroes.onedayherocommon.error.ErrorCode;
 import com.sixheroes.onedayherodomain.mission.MissionCategoryCode;
-import com.sixheroes.onedayherodomain.mission.repository.MissionCategoryRepository;
-import org.junit.jupiter.api.BeforeEach;
+import com.sixheroes.onedayherodomain.mission.MissionStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.data.geo.Point;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Transactional
-@ActiveProfiles("test")
 class MissionServiceTest extends IntegrationApplicationTest {
 
     @Autowired
-    private MissionCategoryRepository missionCategoryRepository;
-
-    @Autowired
     private MissionService missionService;
-
-    @BeforeEach
-    void setUp() {
-        List<MissionCategory> missionCategories = Arrays.stream(MissionCategoryCode.values())
-                .map(MissionCategory::from)
-                .toList();
-
-        missionCategoryRepository.saveAll(missionCategories);
-    }
 
     @DisplayName("시민은 미션을 생성 할 수 있다.")
     @Test
@@ -58,7 +44,89 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var result = missionService.createMission(missionCreateServiceRequest, today);
 
         // then
-        assertThat(result).isNotNull();
+        assertThat(result)
+                .extracting(
+                        "missionCategory",
+                        "citizenId",
+                        "regionId",
+                        "location",
+                        "missionInfo",
+                        "bookmarkCount",
+                        "missionStatus"
+                )
+                .containsExactly(
+                        MissionCategoryResponse.builder()
+                                .categoryId(missionCreateServiceRequest.missionCategoryId())
+                                .code(MissionCategoryCode.MC_001.name())
+                                .name(MissionCategoryCode.MC_001.getDescription())
+                                .build(),
+                        missionCreateServiceRequest.citizenId(),
+                        missionCreateServiceRequest.regionId(),
+                        new Point(missionCreateServiceRequest.latitude(), missionCreateServiceRequest.longitude()),
+                        result.missionInfo(),
+                        0,
+                        MissionStatus.MATCHING.name()
+                );
+    }
+
+    @DisplayName("시민이 미션을 생성 할 때 미션의 수행 날짜가 생성 날짜보다 이전 일 수 없다.")
+    @Test
+    void createMissionWithMissionDateBeforeToday() {
+        // given
+        var today = LocalDateTime.of(2023, 10, 21, 0, 0);
+
+        var missionDate = LocalDate.of(2023, 10, 20);
+        var startTime = LocalTime.of(10, 0, 0);
+        var endTime = LocalTime.of(10, 30, 0);
+        var deadlineTime = LocalTime.of(10, 0, 0);
+
+        var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
+        var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
+
+        // when & then
+        assertThatThrownBy(() -> missionService.createMission(missionCreateServiceRequest, today))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ErrorCode.EM_003.name());
+    }
+
+    @DisplayName("시민이 미션을 생성 할 때 미션의 종료 시간이 시작 시간 이전 일 수 없다.")
+    @Test
+    void createMissionWithEndTimeBeforeStartTime() {
+        // given
+        var today = LocalDateTime.of(2023, 10, 20, 0, 0);
+
+        var missionDate = LocalDate.of(2023, 10, 20);
+        var startTime = LocalTime.of(10, 0, 0);
+        var endTime = LocalTime.of(9, 30, 0);
+        var deadlineTime = LocalTime.of(10, 0, 0);
+
+        var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
+        var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
+
+        // when & then
+        assertThatThrownBy(() -> missionService.createMission(missionCreateServiceRequest, today))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ErrorCode.EM_004.name());
+    }
+
+    @DisplayName("시민이 미션을 생성 할 때 미션의 마감 시간이 시작 시간 이후 일 수 없다.")
+    @Test
+    void createMissionWithDeadLineTimeAfterStartTime() {
+        // given
+        var today = LocalDateTime.of(2023, 10, 20, 0, 0);
+
+        var missionDate = LocalDate.of(2023, 10, 20);
+        var startTime = LocalTime.of(10, 0, 0);
+        var endTime = LocalTime.of(10, 30, 0);
+        var deadlineTime = LocalTime.of(10, 10, 0);
+
+        var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
+        var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
+
+        // when & then
+        assertThatThrownBy(() -> missionService.createMission(missionCreateServiceRequest, today))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ErrorCode.EM_005.name());
     }
 
     private MissionCreateServiceRequest createMissionCreateServiceRequest(

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategory.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "mission_category")
+@Table(name = "m_categories")
 @Entity
 public class MissionCategory {
 

--- a/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionInfoTest.java
+++ b/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionInfoTest.java
@@ -105,7 +105,7 @@ class MissionInfoTest {
                 .hasMessage(ErrorCode.EM_004.name());
     }
 
-    @DisplayName("미션 정보를 입력 받을 때 미션의 종료 시간이 시작 시간 이전 일 수 없다.")
+    @DisplayName("미션 정보를 입력 받을 때 미션의 마감 시간이 시작 시간 이후 일 수 없다.")
     @Test
     void MissionInfoWithDeadLineTimeAfterStartTime() {
         // given


### PR DESCRIPTION
## 🖊️ 1. Changes
- 시민이 미션을 생성 할 때 필요한 비즈니스 로직들을 도메인에서 검증하도록 하였습니다.
- MissionInfo 값 객체에 대한 테스트를 구현하였습니다.
---
- MissionInfo에서 ErrorCode를 불러오지 못하는 문제가 있었습니다. 의존성이 제대로 연결이 되어있지 않은 문제였는데요.
- 먼저, domain TestApplication의 범위를 확인하였습니다. 지금은 최상위 패키지로 옮겨두었는데, 생각해보니 도메인 패키지에서 스프링을 알 필요가 없겠다는 생각이 들어서, 이후 삭제해서 올릴 예정입니다.
- 근본적인 문제는 test 패키지에 의존성이 연결되지 않아서 생긴 문제였습니다.
```java
project(':onedayhero-domain') {
    dependencies {
        compileOnly project(':onedayhero-common')
    }
}
```
현재 root gradle의 설정을 보면 위 처럼 되어있습니다. 여기서 두 가지를 선택 할 수 있습니다.
1️⃣ root gradle에 설정을 추가하기
```java
project(':onedayhero-domain') {
    dependencies {
        compileOnly project(':onedayhero-common')
        testCompileOnly project(':onedayhero-common')
    }
}
```
2️⃣ 하위 모듈에서 의존성을 추가하기
```java
dependencies {
    implementation project(':onedayhero-common')
}
```
실제로 토이 프로젝트에서 진행해봤을 때 implementation을 하지 않으면 라이브러리를 의존 할 수가 없는 문제가 있어, implementation을 추가해줘야 하는 상황을 경험해본것을 근거로 우선 2번 방식으로 해결을 해두었습니다.

- Mission을 생성하는 서비스 로직을 구현하였습니다.
- Mission을 생성하는 서비스 로직을 해피케이스에 대해서 테스트 하였습니다.
- MissionResponse가 MissionInfoResponse를 내부적으로 갖게 하여 동일한 사이클로 취급하였습니다.
- MissionInfo 생성 시에 시간 값 검증에 대한 메서드는 public으로 뺐습니다.
  - Production에서는 LocalDateTime.now()가 들어가는데 그러면 단위테스트를 짜기 어려워 지는 코드가 되어 외부로 빼서 단위 테스트를 짜기 용이하도록 수정하였습니다.
- 현재는 해피 케이스만 테스트 하여 서비스 검증 시 잘못된 값이 들어왔을 경우에 대한 엣지 케이스가 구현이 되어있지 않습니다! 
형진님이 급하실 것 같아서 미리 올려놓습니다~ 우선 테스트가 통과하도록 시간 값에 대한 검증을 Controller 까지 빼두었습니다.
---
- 미션 카테고리의 테이블명이 erd와 다르게 되어있어서 erd에 맞게 변경하였습니다.
- 미션 생성에 대한 엣지 케이스까지 테스트를 구현하였습니다.
- 테스트 진행 간 도메인 테스트에 `DisplayName`이 잘못된 부분이 있어 수정하였습니다.
- 미션 카테고리는 항상 생성되어있는 데이터이기때문에 data.sql 에서 추가되도록 하였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. data.sql 을 생성하면서 계속 오류가 발생했습니다. VALUES의 String 값에 `""(쌍따옴표)`를 사용해서 생긴 문제였고, `''(홑따옴표)`로 변경하니 해결되었습니다. 당시의 예외 메시지는 다음과 같습니다. 참고하세요!
```bash
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'dataSourceScriptDatabaseInitializer' defined in class path resource [org/springframework/boot/autoconfigure/sql/init/DataSourceInitializationConfiguration.class]: Failed to execute SQL script statement #1 of class path resource [sql/data.sql]: INSERT INTO m_categories VALUES (1, "MC_001", "서빙")
```
2. 

## 😌 4. To Reviewer
- 추가적으로, ErrorCode에 있는 T_001 타입의 400을 호출하였습니다. 이러한 도메인 비즈니스 예외 부분을 ErrorCode에 코드로 따로 추가를 하는 것이 좋을까요? ✅
- 검증 할 때, 여러 개의 필드를 검증하다보니 마땅한 이름들이 생각이 안났는데 혹시 보시고 와닿지 않으면 피드백 부탁드립니다. ✅
- 혹은, 좋은 네이밍이 있으면 추천 부탁드립니다! ✅
- gradle 설정에 관한 의견을 들려주세요! ✅
- Service 로직에서 검증하기 힘든 값 같은 경우는 MockTest를 사용할까요? ✅

## ✅ 5. Plans
- [x] - 미션 생성 도메인 로직 구현
- [x] - 미션 생성 도메인 로직 테스트
- [x] - 미션 생성 서비스 로직 구현
- [x] - 미션 생성 서비스 로직 테스트
- [ ] - 미션 생성 api 구현
- [ ] - 미션 생성 api 테스트 

## 🙌 6. Checklist
- [X] - 통합 테스트를 수행해보셨나요?
- [X] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [X] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
