### PR TITLE
[SIX-36] 유저는 미션을 생성 할 수 있다.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -47,27 +47,6 @@ configurations {
     }
 }
 
-project(':onedayhero-api') {
-    dependencies {
-        compileOnly project(':onedayhero-application')
-        compileOnly project(':onedayhero-common')
-    }
-}
-
-project(':onedayhero-application') {
-    dependencies {
-        compileOnly project(':onedayhero-domain')
-        compileOnly project(':onedayhero-infra-querydsl')
-        compileOnly project(':onedayhero-common')
-    }
-}
-
-project(':onedayhero-domain') {
-    dependencies {
-        compileOnly project(':onedayhero-common')
-    }
-}
-
 bootJar.enabled = false
 
 tasks.named('test') {

--- a/onedayhero-api/build.gradle
+++ b/onedayhero-api/build.gradle
@@ -9,8 +9,8 @@ configurations {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    api 'org.springframework.boot:spring-boot-starter-data-jpa'
-    
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+
     implementation project(':onedayhero-common')
     implementation project(':onedayhero-application')
 

--- a/onedayhero-api/build.gradle
+++ b/onedayhero-api/build.gradle
@@ -1,9 +1,50 @@
+plugins {
+    id 'org.asciidoctor.jvm.convert' version '3.3.2'
+}
+
+configurations {
+    asciidoctorExt
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation project(':onedayhero-application')
+
+    // RESTDOCS
+    asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
+    testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 }
 
 tasks.named('test') {
     useJUnitPlatform()
+}
+
+// 전역 변수 설정
+ext {
+    snippetsDir = file('build/generated-snippets')
+}
+
+test {
+    outputs.dir snippetsDir
+}
+
+asciidoctor {
+    inputs.dir snippetsDir
+    configurations 'asciidoctorExt'
+
+    // 특정 파일만 html로 생성
+    sources {
+        include("**/index.adoc")
+    }
+
+    baseDirFollowsSourceFile() // 다른 adoc 파일 include 시 경로를 baseDir로 맞춘다.
+    dependsOn test
+}
+
+bootJar {
+    dependsOn asciidoctor
+    from("${asciidoctor.outputDir}") {
+        into 'static/docs'
+    }
 }

--- a/onedayhero-api/build.gradle
+++ b/onedayhero-api/build.gradle
@@ -9,6 +9,9 @@ configurations {
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    api 'org.springframework.boot:spring-boot-starter-data-jpa'
+    
+    implementation project(':onedayhero-common')
     implementation project(':onedayhero-application')
 
     // RESTDOCS

--- a/onedayhero-api/build.gradle
+++ b/onedayhero-api/build.gradle
@@ -20,6 +20,7 @@ dependencies {
 }
 
 tasks.named('test') {
+    outputs.dir snippetsDir
     useJUnitPlatform()
 }
 
@@ -28,26 +29,33 @@ ext {
     snippetsDir = file('build/generated-snippets')
 }
 
-test {
-    outputs.dir snippetsDir
-}
-
 asciidoctor {
-    inputs.dir snippetsDir
     configurations 'asciidoctorExt'
+
+    baseDirFollowsSourceFile() // 다른 adoc 파일 include 시 경로를 baseDir로 맞춘다.
+
+    inputs.dir snippetsDir
 
     // 특정 파일만 html로 생성
     sources {
         include("**/index.adoc")
     }
 
-    baseDirFollowsSourceFile() // 다른 adoc 파일 include 시 경로를 baseDir로 맞춘다.
     dependsOn test
+    outputDir file('build/docs/asciidoc')
 }
 
-bootJar {
-    dependsOn asciidoctor
-    from("${asciidoctor.outputDir}") {
-        into 'static/docs'
+task copyAsciidoc(type: Copy) {
+    doFirst {
+        delete "src/main/resources/static/docs/index.html"
     }
+    from "build/docs/asciidoc/"
+    into "src/main/resources/static/docs"
+    include "index.html"
+
+    dependsOn asciidoctor
+}
+
+build {
+    dependsOn copyAsciidoc
 }

--- a/onedayhero-api/src/docs/asciidoc/api/mission/mission.adoc
+++ b/onedayhero-api/src/docs/asciidoc/api/mission/mission.adoc
@@ -1,0 +1,12 @@
+[[mission-create]]
+=== 미션 생성
+
+==== HTTP Request
+
+include::{snippets}/mission-create/http-request.adoc[]
+include::{snippets}/mission-create/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/mission-create/http-response.adoc[]
+include::{snippets}/mission-create/response-fields.adoc[]

--- a/onedayhero-api/src/docs/asciidoc/index.adoc
+++ b/onedayhero-api/src/docs/asciidoc/index.adoc
@@ -1,0 +1,15 @@
+ifndef::snippets[]
+:snippets: ../../build/generated-snippets
+endif::[]
+= OneDayHero REST API 문서
+:doctype: book
+:icons: font
+:source-highlighter: highlightjs
+:toc: left
+:toclevels: 2
+:sectlinks:
+
+[[Mission-API]]
+== Mission API
+
+include::api/mission/mission.adoc[]

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/handler/GlobalExceptionHandler.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/handler/GlobalExceptionHandler.java
@@ -3,8 +3,11 @@ package com.sixheroes.onedayheroapi.global.handler;
 import com.sixheroes.onedayheroapi.global.response.ErrorResponse;
 import com.sixheroes.onedayherocommon.error.ErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 
 
@@ -12,6 +15,7 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 @RestControllerAdvice
 public class GlobalExceptionHandler {
 
+    @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
     @ExceptionHandler(value = Exception.class)
     public ErrorResponse handleException(Exception exception) {
         log.error("Error occurred", exception);
@@ -20,11 +24,21 @@ public class GlobalExceptionHandler {
     }
 
     @ExceptionHandler(value = RuntimeException.class)
-    public ErrorResponse handleRuntimeException(RuntimeException exception) {
-        var errorCode = ErrorCode.valueOf(exception.getMessage());
-        return ErrorResponse.from(errorCode);
+    public ResponseEntity<ErrorResponse> handleRuntimeException(RuntimeException exception) {
+        var errorCode = ErrorCode.findByName(exception.getMessage())
+                .orElse(ErrorCode.S_001);
+
+        if (errorCode == ErrorCode.S_001) {
+            log.warn("Error occurred", exception);
+            return ResponseEntity.internalServerError()
+                    .body(ErrorResponse.from(errorCode));
+        }
+
+        return ResponseEntity.badRequest()
+                .body(ErrorResponse.from(errorCode));
     }
 
+    @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ExceptionHandler(value = BindException.class)
     public ErrorResponse handleBindException(BindException exception) {
         var errorCode = ErrorCode.T_001;

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ErrorResponse.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/response/ErrorResponse.java
@@ -1,11 +1,13 @@
 package com.sixheroes.onedayheroapi.global.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.sixheroes.onedayherocommon.error.ErrorCode;
 import lombok.Builder;
 import org.springframework.validation.BindException;
 import org.springframework.validation.FieldError;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 /**
@@ -23,7 +25,10 @@ public record ErrorResponse(
         String message,
 
         @JsonInclude(JsonInclude.Include.NON_EMPTY)
-        List<ValidationError> errors
+        List<ValidationError> errors,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime serverDateTime
 ) {
 
     public static ErrorResponse from(final ErrorCode errorCode) {
@@ -31,6 +36,7 @@ public record ErrorResponse(
                 .code(errorCode.name())
                 .status(errorCode.getStatus())
                 .message(errorCode.getMessage())
+                .serverDateTime(LocalDateTime.now())
                 .build();
     }
 
@@ -43,6 +49,7 @@ public record ErrorResponse(
                 .status(errorCode.getStatus())
                 .message(errorCode.getMessage())
                 .errors(ValidationError.of(e.getBindingResult().getFieldErrors()))
+                .serverDateTime(LocalDateTime.now())
                 .build();
     }
 

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/MissionController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/MissionController.java
@@ -26,7 +26,8 @@ public class MissionController {
     public ResponseEntity<ApiResponse<MissionResponse>> createMission(
             @Valid @RequestBody MissionCreateRequest request
     ) {
-        var result = missionService.createMission(request.toService(), LocalDateTime.now());
+        var registerDateTime = LocalDateTime.now();
+        var result = missionService.createMission(request.toService(), registerDateTime);
 
         return ResponseEntity.created(URI.create("/api/v1/missions/" + result.id()))
                 .body(ApiResponse.created(result));

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/MissionController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/MissionController.java
@@ -1,0 +1,34 @@
+package com.sixheroes.onedayheroapi.mission;
+
+import com.sixheroes.onedayheroapi.global.response.ApiResponse;
+import com.sixheroes.onedayheroapi.mission.request.MissionCreateRequest;
+import com.sixheroes.onedayheroapplication.mission.MissionService;
+import com.sixheroes.onedayheroapplication.mission.response.MissionResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/missions")
+@RestController
+public class MissionController {
+
+    private final MissionService missionService;
+
+    @PostMapping
+    public ResponseEntity<ApiResponse<MissionResponse>> createMission(
+            @Valid @RequestBody MissionCreateRequest request
+    ) {
+        var result = missionService.createMission(request.toService(), LocalDateTime.now());
+
+        return ResponseEntity.created(URI.create("/api/v1/missions/" + result.id()))
+                .body(ApiResponse.created(result));
+    }
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionCreateRequest.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionCreateRequest.java
@@ -16,10 +16,10 @@ public record MissionCreateRequest(
         @NotNull(message = "지역 아이디는 필수 값 입니다.")
         Long regionId,
 
-        @NotNull(message = "경도는 필수 값 입니다.")
+        @NotNull(message = "위도는 필수 값 입니다.")
         Double latitude,
 
-        @NotNull(message = "위도는 필수 값 입니다.")
+        @NotNull(message = "경도는 필수 값 입니다.")
         Double longitude,
 
         @Valid

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionCreateRequest.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionCreateRequest.java
@@ -1,0 +1,39 @@
+package com.sixheroes.onedayheroapi.mission.request;
+
+import com.sixheroes.onedayheroapplication.mission.request.MissionCreateServiceRequest;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+@Builder
+public record MissionCreateRequest(
+        @NotNull(message = "미션의 카테고리 아이디는 필수 값 입니다.")
+        Long missionCategoryId,
+
+        @NotNull(message = "시민의 아이디는 필수 값 입니다.")
+        Long citizenId,
+
+        @NotNull(message = "지역 아이디는 필수 값 입니다.")
+        Long regionId,
+
+        @NotNull(message = "경도는 필수 값 입니다.")
+        Double latitude,
+
+        @NotNull(message = "위도는 필수 값 입니다.")
+        Double longitude,
+
+        @Valid
+        MissionInfoRequest missionInfo
+) {
+
+    public MissionCreateServiceRequest toService() {
+        return MissionCreateServiceRequest.builder()
+                .missionCategoryId(missionCategoryId)
+                .citizenId(citizenId)
+                .regionId(regionId)
+                .latitude(latitude)
+                .longitude(longitude)
+                .missionInfo(missionInfo.toService())
+                .build();
+    }
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionInfoRequest.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionInfoRequest.java
@@ -1,5 +1,6 @@
 package com.sixheroes.onedayheroapi.mission.request;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sixheroes.onedayheroapplication.mission.request.MissionInfoServiceRequest;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
@@ -13,15 +14,19 @@ public record MissionInfoRequest(
         @NotBlank(message = "미션의 내용은 필수 값이며 공백 일 수 없습니다.")
         String content,
 
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
         @NotNull(message = "미션 수행일은 필수 값 입니다.")
         LocalDate missionDate,
 
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
         @NotNull(message = "미션 시작 시간은 필수 값 입니다.")
         LocalTime startTime,
 
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
         @NotNull(message = "미션 종료 시간은 필수 값 입니다.")
         LocalTime endTime,
 
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
         @NotNull(message = "미션 마감 시간은 필수 값 입니다.")
         LocalTime deadlineTime,
 

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionInfoRequest.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionInfoRequest.java
@@ -1,0 +1,42 @@
+package com.sixheroes.onedayheroapi.mission.request;
+
+import com.sixheroes.onedayheroapplication.mission.request.MissionInfoServiceRequest;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Builder;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Builder
+public record MissionInfoRequest(
+        @NotBlank(message = "미션의 내용은 필수 값이며 공백 일 수 없습니다.")
+        String content,
+
+        @NotNull(message = "미션 수행일은 필수 값 입니다.")
+        LocalDate missionDate,
+
+        @NotNull(message = "미션 시작 시간은 필수 값 입니다.")
+        LocalTime startTime,
+
+        @NotNull(message = "미션 종료 시간은 필수 값 입니다.")
+        LocalTime endTime,
+
+        @NotNull(message = "미션 마감 시간은 필수 값 입니다.")
+        LocalTime deadlineTime,
+
+        @NotNull(message = "미션 포상금은 필수 값 입니다.")
+        Integer price
+) {
+
+    public MissionInfoServiceRequest toService() {
+        return MissionInfoServiceRequest.builder()
+                .content(content)
+                .missionDate(missionDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .deadlineTime(deadlineTime)
+                .price(price)
+                .build();
+    }
+}

--- a/onedayhero-api/src/test/java/com/sixheroes/OnedayheroApiApplicationTests.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/OnedayheroApiApplicationTests.java
@@ -1,4 +1,4 @@
-package com.sixheroes.onedayheroapi;
+package com.sixheroes;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/DocumentFormatGenerator.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/DocumentFormatGenerator.java
@@ -1,0 +1,20 @@
+package com.sixheroes.onedayheroapi.docs;
+
+import org.springframework.restdocs.snippet.Attributes;
+
+import static org.springframework.restdocs.snippet.Attributes.key;
+
+public interface DocumentFormatGenerator {
+
+    static Attributes.Attribute getDateFormat() { // 날짜에 대한 data 포맷
+        return key("format").value("yyyy-MM-dd");
+    }
+
+    static Attributes.Attribute getTimeFormat() {
+        return key("format").value("HH:mm");
+    }
+
+    static Attributes.Attribute getDateTimeFormat() {
+        return key("format").value("yyyy-MM-dd'T'HH:mm:ss");
+    }
+}

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
@@ -1,0 +1,35 @@
+package com.sixheroes.onedayheroapi.docs;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sixheroes.onedayheroapi.global.handler.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.restdocs.RestDocumentationContextProvider;
+import org.springframework.restdocs.RestDocumentationExtension;
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+import static org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint;
+
+@ExtendWith(RestDocumentationExtension.class)
+public abstract class RestDocsSupport {
+
+    protected MockMvc mockMvc;
+    protected ObjectMapper objectMapper = new ObjectMapper();
+
+    @BeforeEach
+    void setup(RestDocumentationContextProvider provider) {
+        this.mockMvc = MockMvcBuilders.standaloneSetup(setController())
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .addFilter(new CharacterEncodingFilter("UTF-8", true))
+                .apply(MockMvcRestDocumentation.documentationConfiguration(provider)
+                        .operationPreprocessors()
+                        .withRequestDefaults(prettyPrint())
+                        .withResponseDefaults(prettyPrint()))
+                .build();
+    }
+
+    protected abstract Object setController();
+}

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sixheroes.onedayheroapi.global.handler.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.restdocs.RestDocumentationContextProvider;
 import org.springframework.restdocs.RestDocumentationExtension;
 import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation;
@@ -28,6 +29,7 @@ public abstract class RestDocsSupport {
                         .operationPreprocessors()
                         .withRequestDefaults(prettyPrint())
                         .withResponseDefaults(prettyPrint()))
+                .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver())
                 .build();
     }
 

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
@@ -1,6 +1,7 @@
 package com.sixheroes.onedayheroapi.docs;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sixheroes.onedayheroapi.global.handler.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -18,7 +19,7 @@ import static org.springframework.restdocs.operation.preprocess.Preprocessors.pr
 public abstract class RestDocsSupport {
 
     protected MockMvc mockMvc;
-    protected ObjectMapper objectMapper = new ObjectMapper();
+    protected ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
 
     @BeforeEach
     void setup(RestDocumentationContextProvider provider) {

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionControllerTest.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sixheroes.onedayheroapi.mission.request.MissionCreateRequest;
 import com.sixheroes.onedayheroapi.mission.request.MissionInfoRequest;
 import com.sixheroes.onedayheroapplication.mission.MissionService;
+import com.sixheroes.onedayheroapplication.mission.request.MissionCreateServiceRequest;
 import com.sixheroes.onedayheroapplication.mission.response.MissionCategoryResponse;
 import com.sixheroes.onedayheroapplication.mission.response.MissionResponse;
 import com.sixheroes.onedayherocommon.converter.DateTimeConverter;
@@ -21,7 +22,6 @@ import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
@@ -53,10 +53,9 @@ class MissionControllerTest {
 
         var missionCategoryResponse = createMissionCategoryResponse();
         var missionInfoResponse = createMissionInfoResponse(missionInfoRequest);
-
         var missionResponse = createMissionResponse(missionCategoryResponse, missionCreateRequest, missionInfoResponse);
 
-        given(missionService.createMission(eq(missionCreateRequest.toService()), any(LocalDateTime.class)))
+        given(missionService.createMission(any(MissionCreateServiceRequest.class), any(LocalDateTime.class)))
                 .willReturn(missionResponse);
 
         // when & then
@@ -89,7 +88,11 @@ class MissionControllerTest {
                 .andExpect(jsonPath("$.serverDateTime").exists());
     }
 
-    private MissionResponse createMissionResponse(MissionCategoryResponse missionCategoryResponse, MissionCreateRequest missionCreateRequest, MissionResponse.MissionInfoResponse missionInfoResponse) {
+    private MissionResponse createMissionResponse(
+            MissionCategoryResponse missionCategoryResponse,
+            MissionCreateRequest missionCreateRequest,
+            MissionResponse.MissionInfoResponse missionInfoResponse
+    ) {
         return MissionResponse.builder()
                 .id(1L)
                 .missionCategory(missionCategoryResponse)
@@ -111,7 +114,8 @@ class MissionControllerTest {
     }
 
     private MissionResponse.MissionInfoResponse createMissionInfoResponse(
-            MissionInfoRequest missionInfoRequest) {
+            MissionInfoRequest missionInfoRequest
+    ) {
         return MissionResponse.MissionInfoResponse.builder()
                 .content(missionInfoRequest.content())
                 .missionDate(missionInfoRequest.missionDate())

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionControllerTest.java
@@ -1,0 +1,154 @@
+package com.sixheroes.onedayheroapi.mission;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sixheroes.onedayheroapi.mission.request.MissionCreateRequest;
+import com.sixheroes.onedayheroapi.mission.request.MissionInfoRequest;
+import com.sixheroes.onedayheroapplication.mission.MissionService;
+import com.sixheroes.onedayheroapplication.mission.response.MissionCategoryResponse;
+import com.sixheroes.onedayheroapplication.mission.response.MissionResponse;
+import com.sixheroes.onedayherocommon.converter.DateTimeConverter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.geo.Point;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(MissionController.class)
+class MissionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private MissionService missionService;
+
+    @DisplayName("시민은 미션을 작성 할 수 있다.")
+    @Test
+    void createMission() throws Exception {
+        // given
+        var missionDate = LocalDate.of(2023, 10, 10);
+        var startTime = LocalTime.of(10, 0);
+        var endTime = LocalTime.of(10, 30);
+        var deadlineTime = LocalTime.of(10, 0);
+
+        var missionInfoRequest = createMissionInfoRequest(missionDate, startTime, endTime, deadlineTime);
+        var missionCreateRequest = createMissionCreateRequest(missionInfoRequest);
+
+        var missionCategoryResponse = createMissionCategoryResponse();
+        var missionInfoResponse = createMissionInfoResponse(missionInfoRequest);
+
+        var missionResponse = createMissionResponse(missionCategoryResponse, missionCreateRequest, missionInfoResponse);
+
+        given(missionService.createMission(eq(missionCreateRequest.toService()), any(LocalDateTime.class)))
+                .willReturn(missionResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/missions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(missionCreateRequest))
+                )
+                .andDo(print())
+                .andExpect(header().string("Location", "/api/v1/missions/" + missionResponse.id()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.missionCategory").exists())
+                .andExpect(jsonPath("$.data.missionCategory.categoryId").value(missionCategoryResponse.categoryId()))
+                .andExpect(jsonPath("$.data.missionCategory.code").value(missionCategoryResponse.code()))
+                .andExpect(jsonPath("$.data.missionCategory.name").value(missionCategoryResponse.name()))
+                .andExpect(jsonPath("$.data.location").exists())
+                .andExpect(jsonPath("$.data.location.x").value(missionResponse.location().getX()))
+                .andExpect(jsonPath("$.data.location.y").value(missionResponse.location().getY()))
+                .andExpect(jsonPath("$.data.missionInfo").exists())
+                .andExpect(jsonPath("$.data.missionInfo.content").value(missionInfoResponse.content()))
+                .andExpect(jsonPath("$.data.missionInfo.missionDate").value(DateTimeConverter.convertDateToString(missionInfoResponse.missionDate())))
+                .andExpect(jsonPath("$.data.missionInfo.startTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.startTime())))
+                .andExpect(jsonPath("$.data.missionInfo.endTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.endTime())))
+                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.deadlineTime())))
+                .andExpect(jsonPath("$.data.missionInfo.price").value(missionInfoResponse.price()))
+                .andExpect(jsonPath("$.data.bookmarkCount").value(0))
+                .andExpect(jsonPath("$.data.missionStatus").value(missionResponse.missionStatus()))
+                .andExpect(jsonPath("$.serverDateTime").exists());
+    }
+
+    private MissionResponse createMissionResponse(MissionCategoryResponse missionCategoryResponse, MissionCreateRequest missionCreateRequest, MissionResponse.MissionInfoResponse missionInfoResponse) {
+        return MissionResponse.builder()
+                .id(1L)
+                .missionCategory(missionCategoryResponse)
+                .citizenId(missionCreateRequest.citizenId())
+                .regionId(missionCreateRequest.regionId())
+                .location(new Point(missionCreateRequest.latitude(), missionCreateRequest.latitude()))
+                .missionInfo(missionInfoResponse)
+                .bookmarkCount(0)
+                .missionStatus("MATCHING")
+                .build();
+    }
+
+    private MissionCategoryResponse createMissionCategoryResponse() {
+        return MissionCategoryResponse.builder()
+                .categoryId(1L)
+                .code("MC_001")
+                .name("서빙")
+                .build();
+    }
+
+    private MissionResponse.MissionInfoResponse createMissionInfoResponse(
+            MissionInfoRequest missionInfoRequest) {
+        return MissionResponse.MissionInfoResponse.builder()
+                .content(missionInfoRequest.content())
+                .missionDate(missionInfoRequest.missionDate())
+                .startTime(missionInfoRequest.startTime())
+                .endTime(missionInfoRequest.endTime())
+                .deadlineTime(missionInfoRequest.deadlineTime())
+                .price(missionInfoRequest.price())
+                .build();
+    }
+
+    private MissionCreateRequest createMissionCreateRequest(
+            MissionInfoRequest missionInfoRequest
+    ) {
+        return MissionCreateRequest.builder()
+                .missionCategoryId(1L)
+                .citizenId(1L)
+                .regionId(1L)
+                .latitude(1234252.23)
+                .longitude(1234277.388)
+                .missionInfo(missionInfoRequest)
+                .build();
+    }
+
+    private MissionInfoRequest createMissionInfoRequest(
+            LocalDate missionDate,
+            LocalTime startTime,
+            LocalTime endTime,
+            LocalTime deadlineTime
+    ) {
+        return MissionInfoRequest
+                .builder()
+                .content("내용")
+                .missionDate(missionDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .deadlineTime(deadlineTime)
+                .price(10000)
+                .build();
+    }
+}

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionRestdocs.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionRestdocs.java
@@ -1,0 +1,238 @@
+package com.sixheroes.onedayheroapi.mission;
+
+import com.sixheroes.onedayheroapi.docs.RestDocsSupport;
+import com.sixheroes.onedayheroapi.mission.request.MissionCreateRequest;
+import com.sixheroes.onedayheroapi.mission.request.MissionInfoRequest;
+import com.sixheroes.onedayheroapplication.mission.MissionService;
+import com.sixheroes.onedayheroapplication.mission.request.MissionCreateServiceRequest;
+import com.sixheroes.onedayheroapplication.mission.response.MissionCategoryResponse;
+import com.sixheroes.onedayheroapplication.mission.response.MissionResponse;
+import com.sixheroes.onedayherocommon.converter.DateTimeConverter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.geo.Point;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+
+import static com.sixheroes.onedayheroapi.docs.DocumentFormatGenerator.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.payload.PayloadDocumentation.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+public class MissionRestdocs extends RestDocsSupport {
+
+    private final MissionService missionService = mock(MissionService.class);
+
+    @Override
+    protected Object setController() {
+        return new MissionController(missionService);
+    }
+
+    @DisplayName("유저는 미션을 만들 수 있다.")
+    @Test
+    void createMission() throws Exception {
+        // given
+        var missionDate = LocalDate.of(2023, 10, 10);
+        var startTime = LocalTime.of(10, 0);
+        var endTime = LocalTime.of(10, 30);
+        var deadlineTime = LocalTime.of(10, 0);
+
+        var missionInfoRequest = createMissionInfoRequest(missionDate, startTime, endTime, deadlineTime);
+        var missionCreateRequest = createMissionCreateRequest(missionInfoRequest);
+
+        var missionCategoryResponse = createMissionCategoryResponse();
+        var missionInfoResponse = createMissionInfoResponse(missionInfoRequest);
+        var missionResponse = createMissionResponse(missionCategoryResponse, missionCreateRequest, missionInfoResponse);
+
+        given(missionService.createMission(any(MissionCreateServiceRequest.class), any(LocalDateTime.class)))
+                .willReturn(missionResponse);
+
+        // when & then
+        mockMvc.perform(post("/api/v1/missions")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(missionCreateRequest))
+                )
+                .andDo(print())
+                .andExpect(header().string("Location", "/api/v1/missions/" + missionResponse.id()))
+                .andExpect(status().isCreated())
+                .andDo(document("mission-create",
+                        requestFields(
+                                fieldWithPath("missionCategoryId").type(JsonFieldType.NUMBER)
+                                        .description("카테고리 아이디"),
+                                fieldWithPath("citizenId").type(JsonFieldType.NUMBER)
+                                        .description("시민 아이디"),
+                                fieldWithPath("regionId").type(JsonFieldType.NUMBER)
+                                        .description("지역 아이디"),
+                                fieldWithPath("latitude").type(JsonFieldType.NUMBER)
+                                        .description("위도"),
+                                fieldWithPath("longitude").type(JsonFieldType.NUMBER)
+                                        .description("경도"),
+                                fieldWithPath("missionInfo").type(JsonFieldType.OBJECT)
+                                        .description("미션 상세 정보 객체"),
+                                fieldWithPath("missionInfo.content").type(JsonFieldType.STRING)
+                                        .description("미션 상세 내용"),
+                                fieldWithPath("missionInfo.missionDate").type(JsonFieldType.STRING)
+                                        .description("미션 수행 일")
+                                        .attributes(getDateFormat()),
+                                fieldWithPath("missionInfo.startTime").type(JsonFieldType.STRING)
+                                        .description("미션 시작 시간")
+                                        .attributes(getTimeFormat()),
+                                fieldWithPath("missionInfo.endTime").type(JsonFieldType.STRING)
+                                        .description("미션 종료 시간")
+                                        .attributes(getTimeFormat()),
+                                fieldWithPath("missionInfo.deadlineTime").type(JsonFieldType.STRING)
+                                        .description("미션 마감 시간")
+                                        .attributes(getTimeFormat()),
+                                fieldWithPath("missionInfo.price").type(JsonFieldType.NUMBER)
+                                        .description("미션 포상금")
+                        ),
+                        responseFields(
+                                fieldWithPath("status").type(JsonFieldType.NUMBER)
+                                        .description("HTTP 응답 코드"),
+                                fieldWithPath("data").type(JsonFieldType.OBJECT)
+                                        .description("응답 데이터"),
+                                fieldWithPath("data.id").type(JsonFieldType.NUMBER)
+                                        .description("생성된 미션 아이디"),
+                                fieldWithPath("data.missionCategory").type(JsonFieldType.OBJECT)
+                                        .description("미션 카테고리 정보 객체"),
+                                fieldWithPath("data.citizenId").type(JsonFieldType.NUMBER)
+                                        .description("시민 아이디"),
+                                fieldWithPath("data.regionId").type(JsonFieldType.NUMBER)
+                                        .description("지역 아이디"),
+                                fieldWithPath("data.missionCategory.categoryId").type(JsonFieldType.NUMBER)
+                                        .description("미션 카테고리 아이디"),
+                                fieldWithPath("data.missionCategory.code").type(JsonFieldType.STRING)
+                                        .description("미션 카테고리 코드"),
+                                fieldWithPath("data.missionCategory.name").type(JsonFieldType.STRING)
+                                        .description("미션 카테고리 내용 ex) 청소"),
+                                fieldWithPath("data.location").type(JsonFieldType.OBJECT)
+                                        .description("위도, 경도 정보 객체"),
+                                fieldWithPath("data.location.x").type(JsonFieldType.NUMBER)
+                                        .description("경도 (longitude)"),
+                                fieldWithPath("data.location.y").type(JsonFieldType.NUMBER)
+                                        .description("위도 (latitude)"),
+                                fieldWithPath("data.missionInfo").type(JsonFieldType.OBJECT)
+                                        .description("미션 상세 정보 객체"),
+                                fieldWithPath("data.missionInfo.content").type(JsonFieldType.STRING)
+                                        .description("미션 상세 내용"),
+                                fieldWithPath("data.missionInfo.missionDate").type(JsonFieldType.STRING)
+                                        .description("미션 수행 일")
+                                        .attributes(getDateFormat()),
+                                fieldWithPath("data.missionInfo.startTime").type(JsonFieldType.STRING)
+                                        .description("미션 시작 시간")
+                                        .attributes(getTimeFormat()),
+                                fieldWithPath("data.missionInfo.endTime").type(JsonFieldType.STRING)
+                                        .description("미션 종료 시간")
+                                        .attributes(getTimeFormat()),
+                                fieldWithPath("data.missionInfo.deadlineTime").type(JsonFieldType.STRING)
+                                        .description("미션 마감 시간")
+                                        .attributes(getTimeFormat()),
+                                fieldWithPath("data.missionInfo.price").type(JsonFieldType.NUMBER)
+                                        .description("미션 포상금"),
+                                fieldWithPath("data.bookmarkCount").type(JsonFieldType.NUMBER)
+                                        .description("미션 찜 개수"),
+                                fieldWithPath("data.missionStatus").type(JsonFieldType.STRING)
+                                        .description("미션 진행 상태 (MATCHING)"),
+                                fieldWithPath("serverDateTime").type(JsonFieldType.STRING)
+                                        .description("서버 응답 시간")
+                                        .attributes(getDateTimeFormat())
+                        )))
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.data").exists())
+                .andExpect(jsonPath("$.data.id").value(1))
+                .andExpect(jsonPath("$.data.missionCategory").exists())
+                .andExpect(jsonPath("$.data.missionCategory.categoryId").value(missionCategoryResponse.categoryId()))
+                .andExpect(jsonPath("$.data.missionCategory.code").value(missionCategoryResponse.code()))
+                .andExpect(jsonPath("$.data.missionCategory.name").value(missionCategoryResponse.name()))
+                .andExpect(jsonPath("$.data.location").exists())
+                .andExpect(jsonPath("$.data.location.x").value(missionResponse.location().getX()))
+                .andExpect(jsonPath("$.data.location.y").value(missionResponse.location().getY()))
+                .andExpect(jsonPath("$.data.missionInfo").exists())
+                .andExpect(jsonPath("$.data.missionInfo.content").value(missionInfoResponse.content()))
+                .andExpect(jsonPath("$.data.missionInfo.missionDate").value(DateTimeConverter.convertDateToString(missionInfoResponse.missionDate())))
+                .andExpect(jsonPath("$.data.missionInfo.startTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.startTime())))
+                .andExpect(jsonPath("$.data.missionInfo.endTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.endTime())))
+                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.deadlineTime())))
+                .andExpect(jsonPath("$.data.missionInfo.price").value(missionInfoResponse.price()))
+                .andExpect(jsonPath("$.data.bookmarkCount").value(0))
+                .andExpect(jsonPath("$.data.missionStatus").value(missionResponse.missionStatus()))
+                .andExpect(jsonPath("$.serverDateTime").exists());
+    }
+
+    private MissionResponse createMissionResponse(
+            MissionCategoryResponse missionCategoryResponse,
+            MissionCreateRequest missionCreateRequest,
+            MissionResponse.MissionInfoResponse missionInfoResponse
+    ) {
+        return MissionResponse.builder()
+                .id(1L)
+                .missionCategory(missionCategoryResponse)
+                .citizenId(missionCreateRequest.citizenId())
+                .regionId(missionCreateRequest.regionId())
+                .location(new Point(missionCreateRequest.latitude(), missionCreateRequest.latitude()))
+                .missionInfo(missionInfoResponse)
+                .bookmarkCount(0)
+                .missionStatus("MATCHING")
+                .build();
+    }
+
+    private MissionCategoryResponse createMissionCategoryResponse() {
+        return MissionCategoryResponse.builder()
+                .categoryId(1L)
+                .code("MC_001")
+                .name("서빙")
+                .build();
+    }
+
+    private MissionResponse.MissionInfoResponse createMissionInfoResponse(
+            MissionInfoRequest missionInfoRequest
+    ) {
+        return MissionResponse.MissionInfoResponse.builder()
+                .content(missionInfoRequest.content())
+                .missionDate(missionInfoRequest.missionDate())
+                .startTime(missionInfoRequest.startTime())
+                .endTime(missionInfoRequest.endTime())
+                .deadlineTime(missionInfoRequest.deadlineTime())
+                .price(missionInfoRequest.price())
+                .build();
+    }
+
+    private MissionCreateRequest createMissionCreateRequest(
+            MissionInfoRequest missionInfoRequest
+    ) {
+        return MissionCreateRequest.builder()
+                .missionCategoryId(1L)
+                .citizenId(1L)
+                .regionId(1L)
+                .latitude(1234252.23)
+                .longitude(1234277.388)
+                .missionInfo(missionInfoRequest)
+                .build();
+    }
+
+    private MissionInfoRequest createMissionInfoRequest(
+            LocalDate missionDate,
+            LocalTime startTime,
+            LocalTime endTime,
+            LocalTime deadlineTime
+    ) {
+        return MissionInfoRequest
+                .builder()
+                .content("내용")
+                .missionDate(missionDate)
+                .startTime(startTime)
+                .endTime(endTime)
+                .deadlineTime(deadlineTime)
+                .price(10000)
+                .build();
+    }
+}

--- a/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,12 +1,13 @@
 ==== Request Fields
 |===
-|path|type|Optional|Description
+|path|type|Optional|Format|Description
 
 {{#fields}}
 
 |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
 |{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#format}}`+{{format}}+`{{/format}}{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
 
 {{/fields}}

--- a/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
+++ b/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/request-fields.snippet
@@ -1,0 +1,14 @@
+==== Request Fields
+|===
+|path|type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,12 +1,13 @@
 ==== Response Fields
 |===
-|path|type|Optional|Description
+|path|type|Optional|Format|Description
 
 {{#fields}}
 
 |{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
 |{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
 |{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{#format}}`+{{format}}+`{{/format}}{{/tableCellContent}}
 |{{#tableCellContent}}{{description}}{{/tableCellContent}}
 
 {{/fields}}

--- a/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
+++ b/onedayhero-api/src/test/resources/org/springframework/restdocs/templates/response-fields.snippet
@@ -1,0 +1,14 @@
+==== Response Fields
+|===
+|path|type|Optional|Description
+
+{{#fields}}
+
+|{{#tableCellContent}}`+{{path}}+`{{/tableCellContent}}
+|{{#tableCellContent}}`+{{type}}+`{{/tableCellContent}}
+|{{#tableCellContent}}{{#optional}}O{{/optional}}{{/tableCellContent}}
+|{{#tableCellContent}}{{description}}{{/tableCellContent}}
+
+{{/fields}}
+
+|===

--- a/onedayhero-application/build.gradle
+++ b/onedayhero-application/build.gradle
@@ -1,4 +1,5 @@
 dependencies {
+    implementation project(':onedayhero-common')
     implementation project(':onedayhero-domain')
     implementation project(':onedayhero-infra-querydsl')
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/request/MissionCreateServiceRequest.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/request/MissionCreateServiceRequest.java
@@ -20,7 +20,7 @@ public record MissionCreateServiceRequest(
                 .missionCategory(missionCategory)
                 .citizenId(citizenId)
                 .regionId(regionId)
-                .location(new Point(latitude, longitude))
+                .location(new Point(longitude, latitude))
                 .missionInfo(missionInfo.toVo())
                 .build();
     }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCategoryResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCategoryResponse.java
@@ -1,7 +1,9 @@
 package com.sixheroes.onedayheroapplication.mission.response;
 
 import com.sixheroes.onedayherodomain.mission.MissionCategory;
+import lombok.Builder;
 
+@Builder
 public record MissionCategoryResponse(
         Long categoryId,
         String code,

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponse.java
@@ -37,7 +37,7 @@ public record MissionResponse(
     public record MissionInfoResponse(
             String content,
 
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
             LocalDate missionDate,
 
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponse.java
@@ -1,12 +1,15 @@
 package com.sixheroes.onedayheroapplication.mission.response;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sixheroes.onedayherodomain.mission.Mission;
 import com.sixheroes.onedayherodomain.mission.MissionInfo;
+import lombok.Builder;
 import org.springframework.data.geo.Point;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
 
+@Builder
 public record MissionResponse(
         Long id,
         MissionCategoryResponse missionCategory,
@@ -30,12 +33,22 @@ public record MissionResponse(
         );
     }
 
-    private record MissionInfoResponse(
+    @Builder
+    public record MissionInfoResponse(
             String content,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
             LocalDate missionDate,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
             LocalTime startTime,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
             LocalTime endTime,
+
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
             LocalTime deadlineTime,
+
             Integer price
     ) {
         private MissionInfoResponse(MissionInfo missionInfo) {

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/IntegrationApplicationTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/IntegrationApplicationTest.java
@@ -1,7 +1,9 @@
 package com.sixheroes.onedayheroapplication;
 
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @SpringBootTest
 public abstract class IntegrationApplicationTest {
 

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
@@ -3,42 +3,28 @@ package com.sixheroes.onedayheroapplication.mission;
 import com.sixheroes.onedayheroapplication.IntegrationApplicationTest;
 import com.sixheroes.onedayheroapplication.mission.request.MissionCreateServiceRequest;
 import com.sixheroes.onedayheroapplication.mission.request.MissionInfoServiceRequest;
-import com.sixheroes.onedayherodomain.mission.MissionCategory;
+import com.sixheroes.onedayheroapplication.mission.response.MissionCategoryResponse;
+import com.sixheroes.onedayherocommon.error.ErrorCode;
 import com.sixheroes.onedayherodomain.mission.MissionCategoryCode;
-import com.sixheroes.onedayherodomain.mission.repository.MissionCategoryRepository;
-import org.junit.jupiter.api.BeforeEach;
+import com.sixheroes.onedayherodomain.mission.MissionStatus;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.test.context.ActiveProfiles;
+import org.springframework.data.geo.Point;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.Arrays;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @Transactional
-@ActiveProfiles("test")
 class MissionServiceTest extends IntegrationApplicationTest {
 
     @Autowired
-    private MissionCategoryRepository missionCategoryRepository;
-
-    @Autowired
     private MissionService missionService;
-
-    @BeforeEach
-    void setUp() {
-        List<MissionCategory> missionCategories = Arrays.stream(MissionCategoryCode.values())
-                .map(MissionCategory::from)
-                .toList();
-
-        missionCategoryRepository.saveAll(missionCategories);
-    }
 
     @DisplayName("시민은 미션을 생성 할 수 있다.")
     @Test
@@ -58,7 +44,89 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var result = missionService.createMission(missionCreateServiceRequest, today);
 
         // then
-        assertThat(result).isNotNull();
+        assertThat(result)
+                .extracting(
+                        "missionCategory",
+                        "citizenId",
+                        "regionId",
+                        "location",
+                        "missionInfo",
+                        "bookmarkCount",
+                        "missionStatus"
+                )
+                .containsExactly(
+                        MissionCategoryResponse.builder()
+                                .categoryId(missionCreateServiceRequest.missionCategoryId())
+                                .code(MissionCategoryCode.MC_001.name())
+                                .name(MissionCategoryCode.MC_001.getDescription())
+                                .build(),
+                        missionCreateServiceRequest.citizenId(),
+                        missionCreateServiceRequest.regionId(),
+                        new Point(missionCreateServiceRequest.latitude(), missionCreateServiceRequest.longitude()),
+                        result.missionInfo(),
+                        0,
+                        MissionStatus.MATCHING.name()
+                );
+    }
+
+    @DisplayName("시민이 미션을 생성 할 때 미션의 수행 날짜가 생성 날짜보다 이전 일 수 없다.")
+    @Test
+    void createMissionWithMissionDateBeforeToday() {
+        // given
+        var today = LocalDateTime.of(2023, 10, 21, 0, 0);
+
+        var missionDate = LocalDate.of(2023, 10, 20);
+        var startTime = LocalTime.of(10, 0, 0);
+        var endTime = LocalTime.of(10, 30, 0);
+        var deadlineTime = LocalTime.of(10, 0, 0);
+
+        var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
+        var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
+
+        // when & then
+        assertThatThrownBy(() -> missionService.createMission(missionCreateServiceRequest, today))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ErrorCode.EM_003.name());
+    }
+
+    @DisplayName("시민이 미션을 생성 할 때 미션의 종료 시간이 시작 시간 이전 일 수 없다.")
+    @Test
+    void createMissionWithEndTimeBeforeStartTime() {
+        // given
+        var today = LocalDateTime.of(2023, 10, 20, 0, 0);
+
+        var missionDate = LocalDate.of(2023, 10, 20);
+        var startTime = LocalTime.of(10, 0, 0);
+        var endTime = LocalTime.of(9, 30, 0);
+        var deadlineTime = LocalTime.of(10, 0, 0);
+
+        var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
+        var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
+
+        // when & then
+        assertThatThrownBy(() -> missionService.createMission(missionCreateServiceRequest, today))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ErrorCode.EM_004.name());
+    }
+
+    @DisplayName("시민이 미션을 생성 할 때 미션의 마감 시간이 시작 시간 이후 일 수 없다.")
+    @Test
+    void createMissionWithDeadLineTimeAfterStartTime() {
+        // given
+        var today = LocalDateTime.of(2023, 10, 20, 0, 0);
+
+        var missionDate = LocalDate.of(2023, 10, 20);
+        var startTime = LocalTime.of(10, 0, 0);
+        var endTime = LocalTime.of(10, 30, 0);
+        var deadlineTime = LocalTime.of(10, 10, 0);
+
+        var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
+        var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
+
+        // when & then
+        assertThatThrownBy(() -> missionService.createMission(missionCreateServiceRequest, today))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage(ErrorCode.EM_005.name());
     }
 
     private MissionCreateServiceRequest createMissionCreateServiceRequest(

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
@@ -5,8 +5,11 @@ import com.sixheroes.onedayheroapplication.mission.request.MissionCreateServiceR
 import com.sixheroes.onedayheroapplication.mission.request.MissionInfoServiceRequest;
 import com.sixheroes.onedayheroapplication.mission.response.MissionCategoryResponse;
 import com.sixheroes.onedayherocommon.error.ErrorCode;
+import com.sixheroes.onedayherodomain.mission.MissionCategory;
 import com.sixheroes.onedayherodomain.mission.MissionCategoryCode;
 import com.sixheroes.onedayherodomain.mission.MissionStatus;
+import com.sixheroes.onedayherodomain.mission.repository.MissionCategoryRepository;
+import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,12 +23,18 @@ import java.time.LocalTime;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-@Transactional
 class MissionServiceTest extends IntegrationApplicationTest {
 
     @Autowired
     private MissionService missionService;
 
+    @BeforeAll
+    public static void setUp(@Autowired MissionCategoryRepository missionCategoryRepository) {
+        var missionCategory = MissionCategory.from(MissionCategoryCode.MC_001);
+        missionCategoryRepository.save(missionCategory);
+    }
+
+    @Transactional
     @DisplayName("시민은 미션을 생성 할 수 있다.")
     @Test
     void createMission() {
@@ -69,6 +78,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
                 );
     }
 
+    @Transactional
     @DisplayName("시민이 미션을 생성 할 때 미션의 수행 날짜가 생성 날짜보다 이전 일 수 없다.")
     @Test
     void createMissionWithMissionDateBeforeToday() {
@@ -89,6 +99,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
                 .hasMessage(ErrorCode.EM_003.name());
     }
 
+    @Transactional
     @DisplayName("시민이 미션을 생성 할 때 미션의 종료 시간이 시작 시간 이전 일 수 없다.")
     @Test
     void createMissionWithEndTimeBeforeStartTime() {
@@ -109,6 +120,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
                 .hasMessage(ErrorCode.EM_004.name());
     }
 
+    @Transactional
     @DisplayName("시민이 미션을 생성 할 때 미션의 마감 시간이 시작 시간 이후 일 수 없다.")
     @Test
     void createMissionWithDeadLineTimeAfterStartTime() {

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
@@ -71,7 +71,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
                                 .build(),
                         missionCreateServiceRequest.citizenId(),
                         missionCreateServiceRequest.regionId(),
-                        new Point(missionCreateServiceRequest.latitude(), missionCreateServiceRequest.longitude()),
+                        new Point(missionCreateServiceRequest.longitude(), missionCreateServiceRequest.latitude()),
                         result.missionInfo(),
                         0,
                         MissionStatus.MATCHING.name()

--- a/onedayhero-common/src/main/java/com/sixheroes/onedayherocommon/converter/DateTimeConverter.java
+++ b/onedayhero-common/src/main/java/com/sixheroes/onedayherocommon/converter/DateTimeConverter.java
@@ -1,11 +1,16 @@
 package com.sixheroes.onedayherocommon.converter;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
 
 public final class DateTimeConverter {
 
+    public static String convertLocalDateTimeToString(LocalDateTime localDateTime) {
+        return localDateTime.format(DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss"));
+    }
+    
     public static String convertDateToString(LocalDate localDate) {
         return localDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
     }

--- a/onedayhero-common/src/main/java/com/sixheroes/onedayherocommon/converter/DateTimeConverter.java
+++ b/onedayhero-common/src/main/java/com/sixheroes/onedayherocommon/converter/DateTimeConverter.java
@@ -1,0 +1,16 @@
+package com.sixheroes.onedayherocommon.converter;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.format.DateTimeFormatter;
+
+public final class DateTimeConverter {
+
+    public static String convertDateToString(LocalDate localDate) {
+        return localDate.format(DateTimeFormatter.ofPattern("yyyy-MM-dd"));
+    }
+
+    public static String convertTimetoString(LocalTime localTime) {
+        return localTime.format(DateTimeFormatter.ofPattern("HH:mm"));
+    }
+}

--- a/onedayhero-common/src/main/java/com/sixheroes/onedayherocommon/error/ErrorCode.java
+++ b/onedayhero-common/src/main/java/com/sixheroes/onedayherocommon/error/ErrorCode.java
@@ -3,6 +3,8 @@ package com.sixheroes.onedayherocommon.error;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
+import java.util.Optional;
+
 /**
  * <pre><b>code</b>는 프론트와 정한 에러 코드를 넣어준다.</pre>
  * <pre><b>status</b>는 값에 따라 백엔드에서 넣어준다.</pre>
@@ -28,4 +30,8 @@ public enum ErrorCode {
 
     private final int status;
     private final String message;
+
+    public static Optional<ErrorCode> findByName(String name) {
+        return Optional.of(ErrorCode.valueOf(name));
+    }
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategory.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@Table(name = "mission_category")
+@Table(name = "m_categories")
 @Entity
 public class MissionCategory {
 

--- a/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionInfoTest.java
+++ b/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionInfoTest.java
@@ -105,7 +105,7 @@ class MissionInfoTest {
                 .hasMessage(ErrorCode.EM_004.name());
     }
 
-    @DisplayName("미션 정보를 입력 받을 때 미션의 종료 시간이 시작 시간 이전 일 수 없다.")
+    @DisplayName("미션 정보를 입력 받을 때 미션의 마감 시간이 시작 시간 이후 일 수 없다.")
     @Test
     void MissionInfoWithDeadLineTimeAfterStartTime() {
         // given


### PR DESCRIPTION
## 🖊️ 1. Changes
- 시민이 미션을 생성 할 때 필요한 비즈니스 로직들을 도메인에서 검증하도록 하였습니다.
- MissionInfo 값 객체에 대한 테스트를 구현하였습니다.
---
- MissionInfo에서 ErrorCode를 불러오지 못하는 문제가 있었습니다. 의존성이 제대로 연결이 되어있지 않은 문제였는데요.
- 먼저, domain TestApplication의 범위를 확인하였습니다. 지금은 최상위 패키지로 옮겨두었는데, 생각해보니 도메인 패키지에서 스프링을 알 필요가 없겠다는 생각이 들어서, 이후 삭제해서 올릴 예정입니다.
- 근본적인 문제는 test 패키지에 의존성이 연결되지 않아서 생긴 문제였습니다.
```java
project(':onedayhero-domain') {
    dependencies {
        compileOnly project(':onedayhero-common')
    }
}
```
현재 root gradle의 설정을 보면 위 처럼 되어있습니다. 여기서 두 가지를 선택 할 수 있습니다.
1️⃣ root gradle에 설정을 추가하기
```java
project(':onedayhero-domain') {
    dependencies {
        compileOnly project(':onedayhero-common')
        testCompileOnly project(':onedayhero-common')
    }
}
```
2️⃣ 하위 모듈에서 의존성을 추가하기
```java
dependencies {
    implementation project(':onedayhero-common')
}
```
실제로 토이 프로젝트에서 진행해봤을 때 implementation을 하지 않으면 라이브러리를 의존 할 수가 없는 문제가 있어, implementation을 추가해줘야 하는 상황을 경험해본것을 근거로 우선 2번 방식으로 해결을 해두었습니다.

- Mission을 생성하는 서비스 로직을 구현하였습니다.
- Mission을 생성하는 서비스 로직을 해피케이스에 대해서 테스트 하였습니다.
- MissionResponse가 MissionInfoResponse를 내부적으로 갖게 하여 동일한 사이클로 취급하였습니다.
- MissionInfo 생성 시에 시간 값 검증에 대한 메서드는 public으로 뺐습니다.
  - Production에서는 LocalDateTime.now()가 들어가는데 그러면 단위테스트를 짜기 어려워 지는 코드가 되어 외부로 빼서 단위 테스트를 짜기 용이하도록 수정하였습니다.
- 현재는 해피 케이스만 테스트 하여 서비스 검증 시 잘못된 값이 들어왔을 경우에 대한 엣지 케이스가 구현이 되어있지 않습니다! 
형진님이 급하실 것 같아서 미리 올려놓습니다~ 우선 테스트가 통과하도록 시간 값에 대한 검증을 Controller 까지 빼두었습니다.
- 미션 카테고리의 테이블명이 erd와 다르게 되어있어서 erd에 맞게 변경하였습니다.
- 미션 생성에 대한 엣지 케이스까지 테스트를 구현하였습니다.
- 테스트 진행 간 도메인 테스트에 `DisplayName`이 잘못된 부분이 있어 수정하였습니다.
- 미션 카테고리 생성 문제를 해결하였습니다.
- api 검증 시 시간 값 변환을 위한 날짜 To String Converter를 추가하였습니다.
- api 테스트는 해피 케이스만 테스트 하였습니다!
---
- 날짜의 요청 메시지에 JsonFormat을 추가하였습니다.
- 미션 생성에 대한 restdocs를 추가하였습니다.
- restdocs를 생성하는 gradle과 format에 대한 공통 메서드와 snippets 포맷을 변경하였습니다.

## 🖼️ 2. Screenshot

![image](https://github.com/prgrms-web-devcourse/Team-6Heroes-OneDayHero-BE/assets/74203371/fe265adc-56f1-435f-bba9-a87d679c6696)


## ❗️ 3. Issues

1. data.sql 을 생성하면서 계속 오류가 발생했습니다. VALUES의 String 값에 `""(쌍따옴표)`를 사용해서 생긴 문제였고, `''(홑따옴표)`로 변경하니 해결되었습니다. 당시의 예외 메시지는 다음과 같습니다. 참고하세요!
```bash
org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'dataSourceScriptDatabaseInitializer' defined in class path resource [org/springframework/boot/autoconfigure/sql/init/DataSourceInitializationConfiguration.class]: Failed to execute SQL script statement #1 of class path resource [sql/data.sql]: INSERT INTO m_categories VALUES (1, "MC_001", "서빙")
```
2. restdocs 가 정상적으로 생기지 않는 문제가 있었습니다. copy가 정상적으로 수행되지 않아, 직접 copy를 할 수 있도록 명시함으로서 해결하였습니다.

## 😌 4. To Reviewer
- 추가적으로, ErrorCode에 있는 T_001 타입의 400을 호출하였습니다. 이러한 도메인 비즈니스 예외 부분을 ErrorCode에 코드로 따로 추가를 하는 것이 좋을까요? ✅
- 검증 할 때, 여러 개의 필드를 검증하다보니 마땅한 이름들이 생각이 안났는데 혹시 보시고 와닿지 않으면 피드백 부탁드립니다. ✅
- 혹은, 좋은 네이밍이 있으면 추천 부탁드립니다! ✅
- gradle 설정에 관한 의견을 들려주세요! ✅
- Service 로직에서 검증하기 힘든 값 같은 경우는 MockTest를 사용할까요? ✅

## ✅ 5. Plans
- [x] - 미션 생성 도메인 로직 구현
- [x] - 미션 생성 도메인 로직 테스트
- [x] - 미션 생성 서비스 로직 구현
- [x] - 미션 생성 서비스 로직 테스트
- [x] - 미션 생성 api 구현
- [x] - 미션 생성 api 테스트 
- [x] - 미션 생성 Restdocs 생성

## 🙌 6. Checklist
- [X] - 통합 테스트를 수행해보셨나요?
- [X] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [X] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
