### PR TITLE
[SIX-148] feat : 미션매칭 포기/철회 취소로 통일하는 코드 작성

### DIFF
--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/missionmatch/MissionMatchControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/missionmatch/MissionMatchControllerTest.java
@@ -85,7 +85,7 @@ class MissionMatchControllerTest extends RestDocsSupport {
 
     @DisplayName("시민은 매칭완료 상태인 본인의 미션에 대한 미션매칭을 취소할 수 있다.")
     @Test
-    void withdrawMissionMatch() throws Exception {
+    void cancelMissionMatch() throws Exception {
         // given
         var request = createMissionMatchWithdrawServiceRequest();
         var response = createMissionMatchWithdrawResponse();

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchService.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchService.java
@@ -30,7 +30,7 @@ public class MissionMatchService {
                 request.heroId()
         );
 
-        mission.missionMatchingCompleted(request.userId());
+        mission.completeMissionMatching(request.userId());
         var savedMissionMatch = missionMatchRepository.save(missionMatch);
 
         //TODO: 시민, 히어로에게 미션매칭 성사 알람
@@ -42,7 +42,7 @@ public class MissionMatchService {
         var mission = missionReader.findOne(request.missionId());
         var missionMatch = missionMatchReader.findByMissionId(mission.getId());
 
-        mission.missionMatchingCanceled(request.citizenId());
+        mission.cancelMissionMatching(request.citizenId());
         missionMatch.canceled();
 
         //TODO: 히어로에게 미션매칭 취소 알람

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchService.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchService.java
@@ -24,7 +24,6 @@ public class MissionMatchService {
     private final MissionMatchReader missionMatchReader;
 
     public MissionMatchCreateResponse createMissionMatch(MissionMatchCreateServiceRequest request) {
-        //TODO : UserReader 를 통한 히어로 유저 존재 검증
         var mission = missionReader.findOne(request.missionId());
         var missionMatch = MissionMatch.createMissionMatch(
                 mission.getId(),
@@ -39,12 +38,11 @@ public class MissionMatchService {
         return MissionMatchCreateResponse.from(savedMissionMatch);
     }
 
-    //시민이 미션 매칭 취소
     public MissionMatchCancelResponse cancelMissionMatch(MissionMatchCancelServiceRequest request) {
         var mission = missionReader.findOne(request.missionId());
-        mission.missionMatchingCanceled(request.citizenId());
-
         var missionMatch = missionMatchReader.findByMissionId(mission.getId());
+
+        mission.missionMatchingCanceled(request.citizenId());
         missionMatch.canceled();
 
         //TODO: 히어로에게 미션매칭 취소 알람

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
@@ -138,8 +138,6 @@ class MissionMatchServiceTest extends IntegrationApplicationTest {
                     .isEqualTo(mission.getId());
             soft.assertThat(response.citizenId())
                     .isEqualTo(citizenId);
-            soft.assertThat(response.missionId())
-                    .isEqualTo(mission.getId());
         });
     }
 

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
@@ -11,6 +11,8 @@ import com.sixheroes.onedayherodomain.missionmatch.MissionMatchStatus;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.geo.Point;
 import org.springframework.transaction.annotation.Transactional;
@@ -76,13 +78,16 @@ class MissionMatchServiceTest extends IntegrationApplicationTest {
     }
 
     @DisplayName("시민은 미션이 매칭 중 상태가 아니라면, 매칭완료 상태를 가지는 미션매칭을 생성할 수 없다.")
-    @Test
-    void createMissionMatchingFailWithInvalidStatus() {
+    @EnumSource(value = MissionStatus.class, mode = EnumSource.Mode.EXCLUDE, names = "MATCHING")
+    @ParameterizedTest
+    void createMissionMatchingFailWithInvalidStatus(MissionStatus missionStatus) {
+        System.out.println(missionStatus);
         // given
         var citizenId = 1L;
         var heroId = 2L;
-        var mission = createMission(citizenId);
-        mission.missionMatchingCompleted(citizenId);
+        var mission = createMissionWithStatus(
+                citizenId, missionStatus
+        );
 
         // when & then
         var request = createMissionMatchCreateServiceRequest(
@@ -181,6 +186,23 @@ class MissionMatchServiceTest extends IntegrationApplicationTest {
                 .missionCategory(missionCategoryRepository.findById(1L).get())
                 .bookmarkCount(0)
                 .missionStatus(MissionStatus.MATCHING)
+                .citizenId(citizenId)
+                .regionId(1L)
+                .location(new Point(1234, 5678))
+                .build();
+
+        return missionRepository.save(mission);
+    }
+
+    private Mission createMissionWithStatus(
+            Long citizenId,
+            MissionStatus missionStatus
+    ) {
+        var mission = Mission.builder()
+                .missionInfo(createMissionInfo())
+                .missionCategory(missionCategoryRepository.findById(1L).get())
+                .bookmarkCount(0)
+                .missionStatus(missionStatus)
                 .citizenId(citizenId)
                 .regionId(1L)
                 .location(new Point(1234, 5678))

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
@@ -128,13 +128,13 @@ public class Mission extends BaseEntity {
         }
     }
 
-    public void missionMatchingCompleted(Long userId) {
+    public void completeMissionMatching(Long userId) {
         validateMissionOwnerIsValid(userId);
         validateCurrentMissionStatusIsMatching();
         this.missionStatus = MissionStatus.MATCHING_COMPLETED;
     }
 
-    public void missionMatchingCanceled(Long citizenId) {
+    public void cancelMissionMatching(Long citizenId) {
         validateMissionOwnerIsValid(citizenId);
         validateCurrentMissionStatusIsMatchingCompleted();
         this.missionStatus = MissionStatus.MATCHING;

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatch.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatch.java
@@ -53,7 +53,7 @@ public class MissionMatch {
 
     public void canceled() {
         validateCurrentMissionMatchStatusIsMatchingMatched();
-        this.missionMatchStatus = MissionMatchStatus.WITHDRAW;
+        this.missionMatchStatus = MissionMatchStatus.CANCELED;
     }
 
     private void validateCurrentMissionMatchStatusIsMatchingMatched() {

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatchStatus.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatchStatus.java
@@ -6,9 +6,9 @@ import lombok.RequiredArgsConstructor;
 @Getter
 @RequiredArgsConstructor
 public enum MissionMatchStatus {
-    MATCHED("매칭 됨"),
+    MATCHED("매칭완료"),
     CANCELED("취소"),
-    COMPLETE("완료");
+    COMPLETED("완료");
 
     private final String description;
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatchStatus.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionmatch/MissionMatchStatus.java
@@ -7,8 +7,7 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum MissionMatchStatus {
     MATCHED("매칭 됨"),
-    GIVE_UP("포기"),
-    WITHDRAW("철회"),
+    CANCELED("취소"),
     COMPLETE("완료");
 
     private final String description;


### PR DESCRIPTION
## 🖊️ 1. Changes
- 미션매칭 포기/철회에서 시민만 미션매칭을 취소할 수 있는 비지니스 로직을 반영하여 수정했습니다. 

## 🖼️ 2. Screenshot

## ❗️ 3. Issues

## 😌 4. To Reviewer

## ✅ 5. Plans

## 🙌 6. Checklist
- [x] - 통합 테스트를 수행해보셨나요?
- [x] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [x] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
