### PR TITLE
[SIX-160] Point 컬럼 및 API 호출 이슈 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -34,7 +34,7 @@ subprojects {
         mavenCentral()
     }
 
-    test{
+    test {
         finalizedBy jacocoTestReport
     }
 

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionInfoRequest.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/request/MissionInfoRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Builder
@@ -29,9 +30,9 @@ public record MissionInfoRequest(
         @NotNull(message = "미션 종료 시간은 필수 값 입니다.")
         LocalTime endTime,
 
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
         @NotNull(message = "미션 마감 시간은 필수 값 입니다.")
-        LocalTime deadlineTime,
+        LocalDateTime deadlineTime,
 
         @NotNull(message = "미션 포상금은 필수 값 입니다.")
         Integer price

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionControllerTest.java
@@ -16,7 +16,6 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.SliceImpl;
-import org.springframework.data.geo.Point;
 import org.springframework.http.MediaType;
 import org.springframework.restdocs.payload.JsonFieldType;
 
@@ -135,12 +134,10 @@ public class MissionControllerTest extends RestDocsSupport {
                                         .description("미션 수행 지역 구"),
                                 fieldWithPath("data.region.dong").type(JsonFieldType.STRING)
                                         .description("미션 수행 지역 동"),
-                                fieldWithPath("data.location").type(JsonFieldType.OBJECT)
-                                        .description("위도, 경도 정보 객체"),
-                                fieldWithPath("data.location.x").type(JsonFieldType.NUMBER)
-                                        .description("경도 (longitude)"),
-                                fieldWithPath("data.location.y").type(JsonFieldType.NUMBER)
-                                        .description("위도 (latitude)"),
+                                fieldWithPath("data.longitude").type(JsonFieldType.NUMBER)
+                                        .description("경도"),
+                                fieldWithPath("data.latitude").type(JsonFieldType.NUMBER)
+                                        .description("위도"),
                                 fieldWithPath("data.missionInfo").type(JsonFieldType.OBJECT)
                                         .description("미션 상세 정보 객체"),
                                 fieldWithPath("data.missionInfo.title").type(JsonFieldType.STRING)
@@ -181,9 +178,8 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.region.si").value(regionResponse.si()))
                 .andExpect(jsonPath("$.data.region.gu").value(regionResponse.gu()))
                 .andExpect(jsonPath("$.data.region.dong").value(regionResponse.dong()))
-                .andExpect(jsonPath("$.data.location").exists())
-                .andExpect(jsonPath("$.data.location.x").value(missionResponse.location().getX()))
-                .andExpect(jsonPath("$.data.location.y").value(missionResponse.location().getY()))
+                .andExpect(jsonPath("$.data.longitude").value(missionResponse.longitude()))
+                .andExpect(jsonPath("$.data.latitude").value(missionResponse.latitude()))
                 .andExpect(jsonPath("$.data.missionInfo").exists())
                 .andExpect(jsonPath("$.data.missionInfo.title").value(missionInfoResponse.title()))
                 .andExpect(jsonPath("$.data.missionInfo.content").value(missionInfoResponse.content()))
@@ -330,12 +326,10 @@ public class MissionControllerTest extends RestDocsSupport {
                                         .description("미션 수행 지역 구"),
                                 fieldWithPath("data.region.dong").type(JsonFieldType.STRING)
                                         .description("미션 수행 지역 동"),
-                                fieldWithPath("data.location").type(JsonFieldType.OBJECT)
-                                        .description("위도, 경도 정보 객체"),
-                                fieldWithPath("data.location.x").type(JsonFieldType.NUMBER)
-                                        .description("경도 (longitude)"),
-                                fieldWithPath("data.location.y").type(JsonFieldType.NUMBER)
-                                        .description("위도 (latitude)"),
+                                fieldWithPath("data.longitude").type(JsonFieldType.NUMBER)
+                                        .description("경도"),
+                                fieldWithPath("data.latitude").type(JsonFieldType.NUMBER)
+                                        .description("위도"),
                                 fieldWithPath("data.missionInfo").type(JsonFieldType.OBJECT)
                                         .description("미션 상세 정보 객체"),
                                 fieldWithPath("data.missionInfo.title").type(JsonFieldType.STRING)
@@ -376,9 +370,8 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.region.si").value(regionResponse.si()))
                 .andExpect(jsonPath("$.data.region.gu").value(regionResponse.gu()))
                 .andExpect(jsonPath("$.data.region.dong").value(regionResponse.dong()))
-                .andExpect(jsonPath("$.data.location").exists())
-                .andExpect(jsonPath("$.data.location.x").value(missionResponse.location().getX()))
-                .andExpect(jsonPath("$.data.location.y").value(missionResponse.location().getY()))
+                .andExpect(jsonPath("$.data.longitude").value(missionResponse.longitude()))
+                .andExpect(jsonPath("$.data.latitude").value(missionResponse.latitude()))
                 .andExpect(jsonPath("$.data.missionInfo").exists())
                 .andExpect(jsonPath("$.data.missionInfo.title").value(missionInfoResponse.title()))
                 .andExpect(jsonPath("$.data.missionInfo.content").value(missionInfoResponse.content()))
@@ -483,12 +476,10 @@ public class MissionControllerTest extends RestDocsSupport {
                                         .description("미션 수행 지역 구"),
                                 fieldWithPath("data.region.dong").type(JsonFieldType.STRING)
                                         .description("미션 수행 지역 동"),
-                                fieldWithPath("data.location").type(JsonFieldType.OBJECT)
-                                        .description("위도, 경도 정보 객체"),
-                                fieldWithPath("data.location.x").type(JsonFieldType.NUMBER)
-                                        .description("경도 (longitude)"),
-                                fieldWithPath("data.location.y").type(JsonFieldType.NUMBER)
-                                        .description("위도 (latitude)"),
+                                fieldWithPath("data.longitude").type(JsonFieldType.NUMBER)
+                                        .description("경도"),
+                                fieldWithPath("data.latitude").type(JsonFieldType.NUMBER)
+                                        .description("위도"),
                                 fieldWithPath("data.missionInfo").type(JsonFieldType.OBJECT)
                                         .description("미션 상세 정보 객체"),
                                 fieldWithPath("data.missionInfo.title").type(JsonFieldType.STRING)
@@ -529,9 +520,8 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.region.si").value(regionResponse.si()))
                 .andExpect(jsonPath("$.data.region.gu").value(regionResponse.gu()))
                 .andExpect(jsonPath("$.data.region.dong").value(regionResponse.dong()))
-                .andExpect(jsonPath("$.data.location").exists())
-                .andExpect(jsonPath("$.data.location.x").value(missionResponse.location().getX()))
-                .andExpect(jsonPath("$.data.location.y").value(missionResponse.location().getY()))
+                .andExpect(jsonPath("$.data.longitude").value(missionResponse.longitude()))
+                .andExpect(jsonPath("$.data.latitude").value(missionResponse.latitude()))
                 .andExpect(jsonPath("$.data.missionInfo").exists())
                 .andExpect(jsonPath("$.data.missionInfo.title").value(missionInfoResponse.title()))
                 .andExpect(jsonPath("$.data.missionInfo.content").value(missionInfoResponse.content()))
@@ -604,12 +594,10 @@ public class MissionControllerTest extends RestDocsSupport {
                                         .description("미션 수행 지역 구"),
                                 fieldWithPath("data.region.dong").type(JsonFieldType.STRING)
                                         .description("미션 수행 지역 동"),
-                                fieldWithPath("data.location").type(JsonFieldType.OBJECT)
-                                        .description("위도, 경도 정보 객체"),
-                                fieldWithPath("data.location.x").type(JsonFieldType.NUMBER)
-                                        .description("경도 (longitude)"),
-                                fieldWithPath("data.location.y").type(JsonFieldType.NUMBER)
-                                        .description("위도 (latitude)"),
+                                fieldWithPath("data.longitude").type(JsonFieldType.NUMBER)
+                                        .description("경도"),
+                                fieldWithPath("data.latitude").type(JsonFieldType.NUMBER)
+                                        .description("위도"),
                                 fieldWithPath("data.missionInfo").type(JsonFieldType.OBJECT)
                                         .description("미션 상세 정보 객체"),
                                 fieldWithPath("data.missionInfo.title").type(JsonFieldType.STRING)
@@ -650,9 +638,8 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.region.si").value(regionResponse.si()))
                 .andExpect(jsonPath("$.data.region.gu").value(regionResponse.gu()))
                 .andExpect(jsonPath("$.data.region.dong").value(regionResponse.dong()))
-                .andExpect(jsonPath("$.data.location").exists())
-                .andExpect(jsonPath("$.data.location.x").value(missionResponse.location().getX()))
-                .andExpect(jsonPath("$.data.location.y").value(missionResponse.location().getY()))
+                .andExpect(jsonPath("$.data.longitude").value(missionResponse.longitude()))
+                .andExpect(jsonPath("$.data.latitude").value(missionResponse.latitude()))
                 .andExpect(jsonPath("$.data.missionInfo").exists())
                 .andExpect(jsonPath("$.data.missionInfo.title").value(missionInfoResponse.title()))
                 .andExpect(jsonPath("$.data.missionInfo.content").value(missionInfoResponse.content()))
@@ -888,12 +875,10 @@ public class MissionControllerTest extends RestDocsSupport {
                                         .description("지역 구"),
                                 fieldWithPath("data.missionResponses.content[].region.dong")
                                         .description("지역 동"),
-                                fieldWithPath("data.missionResponses.content[].location").type(JsonFieldType.OBJECT)
-                                        .description("위도 경도 객체"),
-                                fieldWithPath("data.missionResponses.content[].location.x")
-                                        .description("경도 (longitude)"),
-                                fieldWithPath("data.missionResponses.content[].location.y")
-                                        .description("위도 (latitude)"),
+                                fieldWithPath("data.missionResponses.content[].longitude")
+                                        .description("경도"),
+                                fieldWithPath("data.missionResponses.content[].latitude")
+                                        .description("위도"),
                                 fieldWithPath("data.missionResponses.content[].missionInfo").type(JsonFieldType.OBJECT)
                                         .description("미션 상세 정보 객체"),
                                 fieldWithPath("data.missionResponses.content[].missionInfo.title").type(JsonFieldType.STRING)
@@ -972,8 +957,8 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.missionResponses.content[0].region.si").value(missionResponseA.region().si()))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].region.gu").value(missionResponseA.region().gu()))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].region.dong").value(missionResponseA.region().dong()))
-                .andExpect(jsonPath("$.data.missionResponses.content[0].location.x").value(missionResponseA.location().getX()))
-                .andExpect(jsonPath("$.data.missionResponses.content[0].location.y").value(missionResponseA.location().getY()))
+                .andExpect(jsonPath("$.data.missionResponses.content[0].longitude").value(missionResponseA.longitude()))
+                .andExpect(jsonPath("$.data.missionResponses.content[0].latitude").value(missionResponseA.latitude()))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].missionInfo.title").value(missionResponseA.missionInfo().title()))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].missionInfo.content").value(missionResponseA.missionInfo().content()))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].missionInfo.missionDate").value(DateTimeConverter.convertDateToString(missionResponseA.missionInfo().missionDate())))
@@ -1014,7 +999,8 @@ public class MissionControllerTest extends RestDocsSupport {
                 .missionInfo(missionInfoResponse)
                 .bookmarkCount(0)
                 .region(regionResponse)
-                .location(new Point(123.45, 123.56))
+                .longitude(123.45)
+                .latitude(123.45)
                 .missionStatus("MATCHING")
                 .build();
     }
@@ -1030,7 +1016,8 @@ public class MissionControllerTest extends RestDocsSupport {
                 .missionCategory(missionCategoryResponse)
                 .citizenId(missionCreateRequest.citizenId())
                 .region(regionResponse)
-                .location(new Point(missionCreateRequest.latitude(), missionCreateRequest.latitude()))
+                .longitude(missionCreateRequest.longitude())
+                .latitude(missionCreateRequest.latitude())
                 .missionInfo(missionInfoResponse)
                 .bookmarkCount(0)
                 .missionStatus("MATCHING")
@@ -1062,7 +1049,8 @@ public class MissionControllerTest extends RestDocsSupport {
                 .missionCategory(missionCategoryResponse)
                 .citizenId(missionUpdateRequest.citizenId())
                 .region(regionResponse)
-                .location(new Point(missionUpdateRequest.longitude(), missionUpdateRequest.latitude()))
+                .longitude(missionUpdateRequest.longitude())
+                .latitude(missionUpdateRequest.latitude())
                 .missionInfo(missionInfoResponse)
                 .bookmarkCount(0)
                 .missionStatus("MATCHING")

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/mission/MissionControllerTest.java
@@ -53,7 +53,10 @@ public class MissionControllerTest extends RestDocsSupport {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(
+                missionDate,
+                startTime
+        );
 
         var missionInfoRequest = createMissionInfoRequest(missionDate, startTime, endTime, deadlineTime);
         var missionCreateRequest = createMissionCreateRequest(missionInfoRequest);
@@ -186,7 +189,7 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.missionInfo.missionDate").value(DateTimeConverter.convertDateToString(missionInfoResponse.missionDate())))
                 .andExpect(jsonPath("$.data.missionInfo.startTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.startTime())))
                 .andExpect(jsonPath("$.data.missionInfo.endTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.endTime())))
-                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.deadlineTime())))
+                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertLocalDateTimeToString(missionInfoResponse.deadlineTime())))
                 .andExpect(jsonPath("$.data.missionInfo.price").value(missionInfoResponse.price()))
                 .andExpect(jsonPath("$.data.bookmarkCount").value(missionResponse.bookmarkCount()))
                 .andExpect(jsonPath("$.data.missionStatus").value(missionResponse.missionStatus()))
@@ -243,7 +246,10 @@ public class MissionControllerTest extends RestDocsSupport {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(
+                missionDate,
+                startTime
+        );
 
         var missionInfoRequest = createMissionInfoRequest(missionDate, startTime, endTime, deadlineTime);
         var missionUpdateRequest = createMissionUpdateRequest(missionInfoRequest);
@@ -378,7 +384,7 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.missionInfo.missionDate").value(DateTimeConverter.convertDateToString(missionInfoResponse.missionDate())))
                 .andExpect(jsonPath("$.data.missionInfo.startTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.startTime())))
                 .andExpect(jsonPath("$.data.missionInfo.endTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.endTime())))
-                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.deadlineTime())))
+                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertLocalDateTimeToString(missionInfoResponse.deadlineTime())))
                 .andExpect(jsonPath("$.data.missionInfo.price").value(missionInfoResponse.price()))
                 .andExpect(jsonPath("$.data.bookmarkCount").value(missionResponse.bookmarkCount()))
                 .andExpect(jsonPath("$.data.missionStatus").value(missionResponse.missionStatus()))
@@ -393,7 +399,10 @@ public class MissionControllerTest extends RestDocsSupport {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(
+                missionDate,
+                LocalTime.of(10, 0)
+        );
 
         var missionInfoRequest = createMissionInfoRequest(missionDate, startTime, endTime, deadlineTime);
         var missionUpdateRequest = createMissionUpdateRequest(missionInfoRequest);
@@ -528,7 +537,7 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.missionInfo.missionDate").value(DateTimeConverter.convertDateToString(missionInfoResponse.missionDate())))
                 .andExpect(jsonPath("$.data.missionInfo.startTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.startTime())))
                 .andExpect(jsonPath("$.data.missionInfo.endTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.endTime())))
-                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.deadlineTime())))
+                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertLocalDateTimeToString(missionInfoResponse.deadlineTime())))
                 .andExpect(jsonPath("$.data.missionInfo.price").value(missionInfoResponse.price()))
                 .andExpect(jsonPath("$.data.bookmarkCount").value(missionResponse.bookmarkCount()))
                 .andExpect(jsonPath("$.data.missionStatus").value(missionResponse.missionStatus()))
@@ -543,7 +552,10 @@ public class MissionControllerTest extends RestDocsSupport {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(
+                missionDate,
+                LocalTime.of(9, 30)
+        );
 
         var missionInfoRequest = createMissionInfoRequest(missionDate, startTime, endTime, deadlineTime);
         var missionUpdateRequest = createMissionUpdateRequest(missionInfoRequest);
@@ -646,7 +658,7 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.missionInfo.missionDate").value(DateTimeConverter.convertDateToString(missionInfoResponse.missionDate())))
                 .andExpect(jsonPath("$.data.missionInfo.startTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.startTime())))
                 .andExpect(jsonPath("$.data.missionInfo.endTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.endTime())))
-                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertTimetoString(missionInfoResponse.deadlineTime())))
+                .andExpect(jsonPath("$.data.missionInfo.deadlineTime").value(DateTimeConverter.convertLocalDateTimeToString(missionInfoResponse.deadlineTime())))
                 .andExpect(jsonPath("$.data.missionInfo.price").value(missionInfoResponse.price()))
                 .andExpect(jsonPath("$.data.bookmarkCount").value(missionResponse.bookmarkCount()))
                 .andExpect(jsonPath("$.data.missionStatus").value(missionResponse.missionStatus()))
@@ -964,7 +976,7 @@ public class MissionControllerTest extends RestDocsSupport {
                 .andExpect(jsonPath("$.data.missionResponses.content[0].missionInfo.missionDate").value(DateTimeConverter.convertDateToString(missionResponseA.missionInfo().missionDate())))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].missionInfo.startTime").value(DateTimeConverter.convertTimetoString(missionResponseA.missionInfo().startTime())))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].missionInfo.endTime").value(DateTimeConverter.convertTimetoString(missionResponseA.missionInfo().endTime())))
-                .andExpect(jsonPath("$.data.missionResponses.content[0].missionInfo.deadlineTime").value(DateTimeConverter.convertTimetoString(missionResponseA.missionInfo().deadlineTime())))
+                .andExpect(jsonPath("$.data.missionResponses.content[0].missionInfo.deadlineTime").value(DateTimeConverter.convertLocalDateTimeToString(missionResponseA.missionInfo().deadlineTime())))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].missionInfo.price").value(missionResponseA.missionInfo().price()))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].bookmarkCount").value(missionResponseA.bookmarkCount()))
                 .andExpect(jsonPath("$.data.missionResponses.content[0].missionStatus").value(missionResponseA.missionStatus()))
@@ -1033,7 +1045,10 @@ public class MissionControllerTest extends RestDocsSupport {
                 .missionDate(missionDate)
                 .startTime(LocalTime.of(9, 0))
                 .endTime(LocalTime.of(9, 30))
-                .deadlineTime(LocalTime.of(8, 30))
+                .deadlineTime(LocalDateTime.of(
+                        missionDate,
+                        LocalTime.of(8, 30)
+                ))
                 .price(1000)
                 .build();
     }
@@ -1131,7 +1146,7 @@ public class MissionControllerTest extends RestDocsSupport {
             LocalDate missionDate,
             LocalTime startTime,
             LocalTime endTime,
-            LocalTime deadlineTime
+            LocalDateTime deadlineTime
     ) {
         return MissionInfoRequest
                 .builder()

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/MissionService.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/MissionService.java
@@ -104,14 +104,13 @@ public class MissionService {
             MissionFindFilterServiceRequest request
     ) {
         var sliceMissionQueryResponses = missionQueryRepository.findByDynamicCondition(pageable, request.toQuery());
-
-        return MissionResponses.from(pageable, sliceMissionQueryResponses, sliceMissionQueryResponses.hasNext());
+        return MissionResponses.from(sliceMissionQueryResponses);
     }
 
     public MissionProgressResponses findProgressMission(Pageable pageable, Long userId) {
         var sliceMissionProgressQueryResponses = missionQueryRepository.findProgressMissionByUserId(pageable, userId);
 
-        return MissionProgressResponses.from(pageable, sliceMissionProgressQueryResponses, sliceMissionProgressQueryResponses.hasNext());
+        return MissionProgressResponses.from(sliceMissionProgressQueryResponses);
     }
 
     private void deleteUserBookMarkByMissionId(

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/request/MissionCreateServiceRequest.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/request/MissionCreateServiceRequest.java
@@ -3,7 +3,6 @@ package com.sixheroes.onedayheroapplication.mission.request;
 import com.sixheroes.onedayherodomain.mission.Mission;
 import com.sixheroes.onedayherodomain.mission.MissionCategory;
 import lombok.Builder;
-import org.springframework.data.geo.Point;
 
 import java.time.LocalDateTime;
 
@@ -22,7 +21,8 @@ public record MissionCreateServiceRequest(
                 missionCategory,
                 citizenId,
                 regionId,
-                new Point(longitude, latitude),
+                longitude,
+                latitude,
                 missionInfo.toVo(serverTime)
         );
     }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/request/MissionInfoServiceRequest.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/request/MissionInfoServiceRequest.java
@@ -14,7 +14,7 @@ public record MissionInfoServiceRequest(
         LocalDate missionDate,
         LocalTime startTime,
         LocalTime endTime,
-        LocalTime deadlineTime,
+        LocalDateTime deadlineTime,
         Integer price
 ) {
 

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/request/MissionUpdateServiceRequest.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/request/MissionUpdateServiceRequest.java
@@ -3,7 +3,6 @@ package com.sixheroes.onedayheroapplication.mission.request;
 import com.sixheroes.onedayherodomain.mission.Mission;
 import com.sixheroes.onedayherodomain.mission.MissionCategory;
 import lombok.Builder;
-import org.springframework.data.geo.Point;
 
 import java.time.LocalDateTime;
 
@@ -22,7 +21,7 @@ public record MissionUpdateServiceRequest(
                 .missionCategory(missionCategory)
                 .citizenId(citizenId)
                 .regionId(regionId)
-                .location(new Point(longitude, latitude))
+                .location(Mission.createPoint(longitude, latitude))
                 .missionInfo(missionInfo.toVo(serverTime))
                 .build();
     }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionProgressResponses.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionProgressResponses.java
@@ -2,9 +2,7 @@ package com.sixheroes.onedayheroapplication.mission.response;
 
 import com.sixheroes.onedayheroquerydsl.mission.response.MissionProgressQueryResponse;
 import lombok.Builder;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 
 @Builder
 public record MissionProgressResponses(
@@ -12,15 +10,9 @@ public record MissionProgressResponses(
 ) {
 
     public static MissionProgressResponses from(
-            Pageable pageable,
-            Slice<MissionProgressQueryResponse> response,
-            boolean hasNext
+            Slice<MissionProgressQueryResponse> response
     ) {
-        var missionProgressResponses = response.stream()
-                .map(MissionProgressResponse::from)
-                .toList();
-
-        var missionProgressResponseSlice = new SliceImpl<>(missionProgressResponses, pageable, hasNext);
-        return new MissionProgressResponses(missionProgressResponseSlice);
+        var mappedMissionProgressResponse = response.map(MissionProgressResponse::from);
+        return new MissionProgressResponses(mappedMissionProgressResponse);
     }
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponse.java
@@ -7,7 +7,6 @@ import com.sixheroes.onedayherodomain.mission.MissionInfo;
 import com.sixheroes.onedayherodomain.region.Region;
 import com.sixheroes.onedayheroquerydsl.mission.response.MissionQueryResponse;
 import lombok.Builder;
-import org.springframework.data.geo.Point;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
@@ -18,7 +17,8 @@ public record MissionResponse(
         MissionCategoryResponse missionCategory,
         Long citizenId,
         RegionResponse region,
-        Point location,
+        Double longitude,
+        Double latitude,
         MissionInfoResponse missionInfo,
         Integer bookmarkCount,
         String missionStatus
@@ -34,7 +34,8 @@ public record MissionResponse(
                 .region(
                         RegionResponse.from(response)
                 )
-                .location(response.location())
+                .longitude(response.location().getX())
+                .latitude(response.location().getY())
                 .missionInfo(
                         MissionInfoResponse.from(response)
                 )
@@ -53,7 +54,8 @@ public record MissionResponse(
                 .region(
                         RegionResponse.from(region)
                 )
-                .location(mission.getLocation())
+                .longitude(mission.getLocation().getX())
+                .latitude(mission.getLocation().getY())
                 .missionInfo(MissionInfoResponse.from(mission.getMissionInfo()))
                 .bookmarkCount(mission.getBookmarkCount())
                 .missionStatus(mission.getMissionStatus().name())

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponse.java
@@ -9,6 +9,7 @@ import com.sixheroes.onedayheroquerydsl.mission.response.MissionQueryResponse;
 import lombok.Builder;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 @Builder
@@ -77,8 +78,8 @@ public record MissionResponse(
             @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
             LocalTime endTime,
 
-            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-            LocalTime deadlineTime,
+            @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+            LocalDateTime deadlineTime,
 
             Integer price
     ) {
@@ -87,6 +88,7 @@ public record MissionResponse(
                 MissionQueryResponse response
         ) {
             return MissionInfoResponse.builder()
+                    .title(response.title())
                     .content(response.content())
                     .missionDate(response.missionDate())
                     .startTime(response.startTime())
@@ -100,6 +102,7 @@ public record MissionResponse(
                 MissionInfo missionInfo
         ) {
             return MissionInfoResponse.builder()
+                    .title(missionInfo.getTitle())
                     .content(missionInfo.getContent())
                     .missionDate(missionInfo.getMissionDate())
                     .startTime(missionInfo.getStartTime())

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponses.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionResponses.java
@@ -1,24 +1,16 @@
 package com.sixheroes.onedayheroapplication.mission.response;
 
 import com.sixheroes.onedayheroquerydsl.mission.response.MissionQueryResponse;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
-import org.springframework.data.domain.SliceImpl;
 
 public record MissionResponses(
         Slice<MissionResponse> missionResponses
 ) {
 
     public static MissionResponses from(
-            Pageable pageable,
-            Slice<MissionQueryResponse> response,
-            boolean hasNext
+            Slice<MissionQueryResponse> response
     ) {
-        var missionResponses = response.stream()
-                .map(MissionResponse::from)
-                .toList();
-
-        var resultMissionResponses = new SliceImpl<>(missionResponses, pageable, hasNext);
-        return new MissionResponses(resultMissionResponses);
+        var mappedMissionResponse = response.map(MissionResponse::from);
+        return new MissionResponses(mappedMissionResponse);
     }
 }

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionBookmarkServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionBookmarkServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.geo.Point;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -128,7 +127,7 @@ class MissionBookmarkServiceTest extends IntegrationApplicationTest {
                 .missionCategory(missionCategoryRepository.findById(1L).get())
                 .citizenId(citizenId)
                 .regionId(1L)
-                .location(new Point(1234, 5678))
+                .location(Mission.createPoint(1234.56, 1234.78))
                 .bookmarkCount(0)
                 .build();
 

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionBookmarkServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionBookmarkServiceTest.java
@@ -139,7 +139,10 @@ class MissionBookmarkServiceTest extends IntegrationApplicationTest {
                 .missionDate(LocalDate.of(2023, 10, 10))
                 .startTime(LocalTime.of(10, 0))
                 .endTime(LocalTime.of(10, 30))
-                .deadlineTime(LocalTime.of(10, 0))
+                .deadlineTime(LocalDateTime.of(
+                        LocalDate.of(2023, 10, 10),
+                        LocalTime.of(10, 0)
+                ))
                 .price(10000)
                 .title("서빙")
                 .content("서빙 도와주기")

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
@@ -19,7 +19,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.geo.Point;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -97,7 +96,8 @@ class MissionServiceTest extends IntegrationApplicationTest {
                         "missionCategory",
                         "citizenId",
                         "region",
-                        "location",
+                        "longitude",
+                        "latitude",
                         "missionInfo",
                         "bookmarkCount",
                         "missionStatus"
@@ -106,7 +106,8 @@ class MissionServiceTest extends IntegrationApplicationTest {
                         MissionCategoryResponse.from(missionCategory),
                         missionCreateServiceRequest.citizenId(),
                         RegionResponse.from(region),
-                        new Point(missionCreateServiceRequest.longitude(), missionCreateServiceRequest.latitude()),
+                        missionCreateServiceRequest.longitude(),
+                        missionCreateServiceRequest.latitude(),
                         result.missionInfo(),
                         0,
                         MissionStatus.MATCHING.name()
@@ -349,7 +350,8 @@ class MissionServiceTest extends IntegrationApplicationTest {
                         "missionCategory",
                         "citizenId",
                         "region",
-                        "location",
+                        "longitude",
+                        "latitude",
                         "missionInfo",
                         "bookmarkCount",
                         "missionStatus"
@@ -358,7 +360,8 @@ class MissionServiceTest extends IntegrationApplicationTest {
                         MissionCategoryResponse.from(updateMissionCategory),
                         missionUpdateServiceRequest.citizenId(),
                         RegionResponse.from(region),
-                        new Point(missionUpdateServiceRequest.longitude(), missionUpdateServiceRequest.latitude()),
+                        missionUpdateServiceRequest.longitude(),
+                        missionUpdateServiceRequest.latitude(),
                         result.missionInfo(),
                         0,
                         MissionStatus.MATCHING.name()
@@ -793,7 +796,8 @@ class MissionServiceTest extends IntegrationApplicationTest {
                         "missionCategory",
                         "citizenId",
                         "region",
-                        "location",
+                        "longitude",
+                        "latitude",
                         "missionInfo",
                         "bookmarkCount",
                         "missionStatus"
@@ -802,7 +806,8 @@ class MissionServiceTest extends IntegrationApplicationTest {
                         MissionCategoryResponse.from(missionCategory),
                         citizenId,
                         RegionResponse.from(region),
-                        mission.getLocation(),
+                        mission.getLocation().getX(),
+                        mission.getLocation().getY(),
                         result.missionInfo(),
                         0,
                         MissionStatus.MATCHING.name()
@@ -865,7 +870,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
                                 .build())
                 .regionId(1L)
                 .citizenId(citizenId)
-                .location(new Point(123456.78, 123456.78))
+                .location(Mission.createPoint(123456.78, 123456.89))
                 .bookmarkCount(0)
                 .missionStatus(missionStatus)
                 .build();

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionServiceTest.java
@@ -77,7 +77,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
         var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
@@ -124,7 +124,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 20);
         var startTime = LocalTime.of(10, 0, 0);
         var endTime = LocalTime.of(10, 30, 0);
-        var deadlineTime = LocalTime.of(10, 0, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
         var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
@@ -145,7 +145,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 20);
         var startTime = LocalTime.of(10, 0, 0);
         var endTime = LocalTime.of(9, 30, 0);
-        var deadlineTime = LocalTime.of(10, 0, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
         var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
@@ -166,7 +166,10 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 20);
         var startTime = LocalTime.of(10, 0, 0);
         var endTime = LocalTime.of(10, 30, 0);
-        var deadlineTime = LocalTime.of(10, 10, 0);
+        var deadlineTime = LocalDateTime.of(
+                missionDate,
+                startTime.plusMinutes(1)
+        );
 
         var missionInfoServiceRequest = createMissionInfoServiceRequest(missionDate, startTime, endTime, deadlineTime);
         var missionCreateServiceRequest = createMissionCreateServiceRequest(missionInfoServiceRequest);
@@ -191,7 +194,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -237,7 +240,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -270,7 +273,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -305,7 +308,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var region = regionRepository.findById(1L).get();
 
@@ -380,7 +383,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -437,7 +440,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -480,7 +483,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
                 .hasMessage(ErrorCode.EM_009.name());
     }
 
-    @DisplayName("시민이 미션을 생성 할 때 미션의 종료 시간이 시작 시간 이전 일 수 없다.")
+    @DisplayName("시민이 미션을 수정 할 때 미션 일이 현재보다 이전 일 수 없다.")
     @Test
     void updateMissionWithMissionDateBeforeToday() {
         // given
@@ -492,7 +495,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -548,7 +551,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -592,7 +595,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
                 .hasMessage(ErrorCode.EM_004.name());
     }
 
-    @DisplayName("시민이 미션을 수정 할 때 미션의 수행 일이 현재 날짜 이전 일 수 없다.")
+    @DisplayName("시민이 미션을 수정 할 때 미션의 종료 시간이 시작 시간보다 빠를 수 없다.")
     @Test
     void updateMissionWithEndTimeBeforeStartTime() {
         // given
@@ -604,7 +607,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -623,11 +626,11 @@ class MissionServiceTest extends IntegrationApplicationTest {
                 savedMission.getMissionInfo().getMissionDate().minusDays(1),
                 LocalTime.MIDNIGHT
         );
-
+        
         var missionInfoServiceRequest = createMissionInfoServiceRequest(
                 savedMission.getMissionInfo().getMissionDate().plusDays(2),
-                savedMission.getMissionInfo().getStartTime().plusHours(2),
-                savedMission.getMissionInfo().getEndTime().plusHours(3),
+                savedMission.getMissionInfo().getStartTime().plusHours(3),
+                savedMission.getMissionInfo().getEndTime().plusHours(2),
                 savedMission.getMissionInfo().getDeadlineTime().plusHours(3)
         );
 
@@ -645,7 +648,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         // when & then
         assertThatThrownBy(() -> missionService.updateMission(mission.getId(), missionUpdateServiceRequest, today))
                 .isInstanceOf(IllegalArgumentException.class)
-                .hasMessage(ErrorCode.EM_005.name());
+                .hasMessage(ErrorCode.EM_004.name());
     }
 
     @DisplayName("시민은 마감된 미션에 대해서만 미션을 연장 할 수 있다.")
@@ -661,7 +664,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -716,7 +719,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -772,7 +775,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var mission = createMission(
                 missionCategory,
@@ -831,7 +834,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
             LocalDate missionDate,
             LocalTime startTime,
             LocalTime endTime,
-            LocalTime deadlineTime
+            LocalDateTime deadlineTime
     ) {
         return MissionInfoServiceRequest
                 .builder()
@@ -851,7 +854,7 @@ class MissionServiceTest extends IntegrationApplicationTest {
             LocalDate missionDate,
             LocalTime startTime,
             LocalTime endTime,
-            LocalTime deadlineTime,
+            LocalDateTime deadlineTime,
             LocalDateTime serverTime,
             MissionStatus missionStatus
     ) {

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
@@ -11,7 +11,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.geo.Point;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -175,7 +174,7 @@ class MissionMatchServiceTest extends IntegrationApplicationTest {
                 .missionStatus(MissionStatus.MATCHING)
                 .citizenId(citizenId)
                 .regionId(1L)
-                .location(new Point(1234, 5678))
+                .location(Mission.createPoint(1234.56, 1234.78))
                 .build();
 
         return missionRepository.save(mission);

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
@@ -204,7 +204,7 @@ class MissionMatchServiceTest extends IntegrationApplicationTest {
                 .missionStatus(missionStatus)
                 .citizenId(citizenId)
                 .regionId(1L)
-                .location(new Point(1234, 5678))
+                .location(Mission.createPoint(1234.56, 1234.56))
                 .build();
 
         return missionRepository.save(mission);

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/missionmatch/MissionMatchServiceTest.java
@@ -215,7 +215,10 @@ class MissionMatchServiceTest extends IntegrationApplicationTest {
                 .missionDate(LocalDate.of(2023, 10, 10))
                 .startTime(LocalTime.of(10, 0))
                 .endTime(LocalTime.of(10, 30))
-                .deadlineTime(LocalTime.of(10, 0))
+                .deadlineTime(LocalDateTime.of(
+                        LocalDate.of(2023, 10, 10),
+                        LocalTime.of(10, 0)
+                ))
                 .price(10000)
                 .title("서빙")
                 .content("서빙 도와주기")

--- a/onedayhero-common/build.gradle
+++ b/onedayhero-common/build.gradle
@@ -1,11 +1,15 @@
 ext {
     jjwtVersion = '0.11.5'
-    mysqlJdbcDriverVersion = '8.0.33'
+    mysqlVersion = '8.0.33'
 }
 
 dependencies {
     //MySQL
-    api "mysql:mysql-connector-java:${mysqlJdbcDriverVersion}"
+    api "mysql:mysql-connector-java:${mysqlVersion}"
+
+    //Spatial
+    api 'org.hibernate:hibernate-spatial:6.3.1.Final'
+    api 'com.querydsl:querydsl-spatial'
 
     //JWT
     runtimeOnly "io.jsonwebtoken:jjwt-jackson:${jjwtVersion}"

--- a/onedayhero-common/build.gradle
+++ b/onedayhero-common/build.gradle
@@ -1,5 +1,3 @@
-dependencies {
-
 ext {
     jjwtVersion = '0.11.5'
     mysqlVersion = '8.0.33'

--- a/onedayhero-domain/build.gradle
+++ b/onedayhero-domain/build.gradle
@@ -1,6 +1,5 @@
 dependencies {
     api 'org.springframework.boot:spring-boot-starter-data-jpa'
-    api 'org.hibernate:hibernate-spatial:6.2.13.Final'
     api 'io.hypersistence:hypersistence-utils-hibernate-62:3.6.0'
     api 'com.fasterxml.jackson.module:jackson-module-jakarta-xmlbind-annotations'
     api 'com.h2database:h2'

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
@@ -112,13 +112,16 @@ public class Mission extends BaseEntity {
         this.location = mission.location;
     }
 
-    public void extend(Mission mission) {
+    public void extend(
+            Mission mission
+    ) {
         validOwn(mission.citizenId);
         validAbleExtend();
         this.missionCategory = mission.missionCategory;
         this.missionInfo = mission.missionInfo;
         this.regionId = mission.regionId;
         this.location = mission.location;
+        this.missionStatus = MissionStatus.MATCHING;
     }
 
     public void validAbleDelete(

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/Mission.java
@@ -11,7 +11,10 @@ import lombok.extern.slf4j.Slf4j;
 import org.hibernate.annotations.DynamicUpdate;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.GeometryFactory;
+import org.locationtech.jts.geom.Point;
+import org.locationtech.jts.geom.PrecisionModel;
 
 @Slf4j
 @Getter
@@ -53,6 +56,7 @@ public class Mission extends BaseEntity {
     @Column(name = "is_deleted", nullable = false)
     private Boolean isDeleted;
 
+    // TODO : 미션 생성 시 전달 받는 값을 longitude, latitude 로 분리하고 생성자에서 Point 변환
     @Builder
     private Mission(
             MissionCategory missionCategory,
@@ -73,18 +77,24 @@ public class Mission extends BaseEntity {
         this.isDeleted = false;
     }
 
+    public static Point createPoint(double x, double y) {
+        var geometryFactory = new GeometryFactory(new PrecisionModel(), 4326);
+        return geometryFactory.createPoint(new Coordinate(x, y));
+    }
+
     public static Mission createMission(
             MissionCategory missionCategory,
             Long citizenId,
             Long regionId,
-            Point location,
+            double longitude,
+            double latitude,
             MissionInfo missionInfo
     ) {
         return Mission.builder().
                 missionCategory(missionCategory)
                 .citizenId(citizenId)
                 .regionId(regionId)
-                .location(location)
+                .location(createPoint(longitude, latitude))
                 .missionInfo(missionInfo)
                 .bookmarkCount(0)
                 .missionStatus(MissionStatus.MATCHING)

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategoryCode.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionCategoryCode.java
@@ -11,7 +11,7 @@ public enum MissionCategoryCode {
     MC_003(3L, "배달, 운전"),
     MC_004(4L, "카페"),
     MC_005(5L, "청소"),
-    MC_006(6L, "헬스"),
+    MC_006(6L, "행사"),
     MC_007(7L, "포장, 물류"),
     MC_008(8L, "기타");
 

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionInfo.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/MissionInfo.java
@@ -36,7 +36,7 @@ public class MissionInfo {
     private LocalTime endTime;
 
     @Column(name = "deadline_time", nullable = false)
-    private LocalTime deadlineTime;
+    private LocalDateTime deadlineTime;
 
     @Column(name = "price", nullable = false)
     private Integer price;
@@ -50,7 +50,7 @@ public class MissionInfo {
             LocalDate missionDate,
             LocalTime startTime,
             LocalTime endTime,
-            LocalTime deadlineTime,
+            LocalDateTime deadlineTime,
             Integer price,
             LocalDateTime serverTime
     ) {
@@ -91,12 +91,11 @@ public class MissionInfo {
             LocalDate missionDate,
             LocalTime startTime,
             LocalTime endTime,
-            LocalTime deadlineTime,
+            LocalDateTime deadlineTime,
             LocalDateTime serverTime
     ) {
         var startDateTime = LocalDateTime.of(missionDate, startTime);
         var endDateTime = LocalDateTime.of(missionDate, endTime);
-        var deadLineDateTime = LocalDateTime.of(missionDate, deadlineTime);
 
         if (missionDate.isBefore(serverTime.toLocalDate())) {
             log.warn("미션의 수행 날짜가 현재 날짜보다 이전 일 수 없습니다. 수행 일 : {}, 현재 날짜 : {}", missionDate, serverTime.toLocalDate());
@@ -108,8 +107,8 @@ public class MissionInfo {
             throw new IllegalArgumentException(ErrorCode.EM_004.name());
         }
 
-        if (deadLineDateTime.isAfter(startDateTime)) {
-            log.warn("미션의 마감 시간이 시작 시간 이후 일 수 없습니다. 시작 시간 : {}, 마감 시간 : {}", startDateTime, deadLineDateTime);
+        if (deadlineTime.isAfter(startDateTime)) {
+            log.warn("미션의 마감 시간이 시작 시간 이후 일 수 없습니다. 시작 시간 : {}, 마감 시간 : {}", startDateTime, deadlineTime);
             throw new IllegalArgumentException(ErrorCode.EM_005.name());
         }
     }

--- a/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionInfoTest.java
+++ b/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionInfoTest.java
@@ -28,7 +28,7 @@ class MissionInfoTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
         var price = 1000;
 
         var missionInfo = MissionInfo.builder()
@@ -104,7 +104,7 @@ class MissionInfoTest {
         var missionDate = LocalDate.of(2023, 10, 20);
         var startTime = LocalTime.of(10, 0, 0);
         var endTime = LocalTime.of(10, 30, 0);
-        var deadlineTime = LocalTime.of(10, 0, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
 
         // when & then
@@ -122,7 +122,7 @@ class MissionInfoTest {
         var missionDate = LocalDate.of(2023, 10, 20);
         var startTime = LocalTime.of(10, 0, 0);
         var endTime = LocalTime.of(9, 30, 0);
-        var deadlineTime = LocalTime.of(10, 0, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         // when & then
         assertThatThrownBy(() -> createMissionInfo(missionDate, startTime, endTime, deadlineTime, serverTime))
@@ -139,7 +139,7 @@ class MissionInfoTest {
         var missionDate = LocalDate.of(2023, 10, 20);
         var startTime = LocalTime.of(10, 0, 0);
         var endTime = LocalTime.of(10, 30, 0);
-        var deadlineTime = LocalTime.of(10, 10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime.plusMinutes(30));
 
         // when & then
         assertThatThrownBy(() -> createMissionInfo(missionDate, startTime, endTime, deadlineTime, serverTime))
@@ -152,7 +152,7 @@ class MissionInfoTest {
             LocalDate missionDate,
             LocalTime startTime,
             LocalTime endTime,
-            LocalTime deadlineTime,
+            LocalDateTime deadlineTime,
             LocalDateTime serverTime
     ) {
         return MissionInfo.builder()
@@ -177,7 +177,10 @@ class MissionInfoTest {
                 .missionDate(LocalDate.of(2023, 10, 10))
                 .startTime(LocalTime.of(10, 0, 0))
                 .endTime(LocalTime.of(10, 30, 0))
-                .deadlineTime(LocalTime.of(10, 0, 0))
+                .deadlineTime(LocalDateTime.of(
+                        LocalDate.of(2023, 10, 10),
+                        LocalTime.of(10, 0, 0)
+                ))
                 .price(1000)
                 .serverTime(LocalDateTime.of(
                         LocalDate.of(2023, 10, 9),

--- a/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionTest.java
+++ b/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionTest.java
@@ -203,6 +203,42 @@ class MissionTest {
                 .hasMessage(ErrorCode.T_001.name());
     }
 
+    @DisplayName("유저는 만료된 미션을 연장 할 수 있다.")
+    @Test
+    void extendMission() {
+        // given
+        var expiredMission = createMission(MissionStatus.EXPIRED);
+
+        var extendMission = Mission.builder()
+                .citizenId(expiredMission.getCitizenId())
+                .regionId(expiredMission.getRegionId())
+                .missionCategory(expiredMission.getMissionCategory())
+                .missionInfo(MissionInfo.builder()
+                        .serverTime(LocalDateTime.of(
+                                LocalDate.of(2023, 11, 7),
+                                LocalTime.MIDNIGHT
+                        ))
+                        .title("수정된 제목")
+                        .content("수정된 내용")
+                        .missionDate(LocalDate.of(2023, 11, 9))
+                        .startTime(LocalTime.of(10, 0))
+                        .endTime(LocalTime.of(10, 30))
+                        .deadlineTime(LocalDateTime.of(
+                                LocalDate.of(2023, 11, 9),
+                                LocalTime.of(10, 0)
+                        ))
+                        .price(1500)
+                        .build())
+                .location(Mission.createPoint(1234.56, 1234.56))
+                .build();
+        
+        // when
+        expiredMission.extend(extendMission);
+
+        // then
+        assertThat(expiredMission.getMissionStatus()).isEqualTo(MissionStatus.MATCHING);
+    }
+
     private Mission createMission(
             MissionStatus missionStatus
     ) {

--- a/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionTest.java
+++ b/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionTest.java
@@ -5,7 +5,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
-import org.springframework.data.geo.Point;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -229,7 +228,7 @@ class MissionTest {
                                 .build())
                 .regionId(1L)
                 .citizenId(1L)
-                .location(new Point(123456.78, 123456.78))
+                .location(Mission.createPoint(123456.78, 123456.78))
                 .missionStatus(missionStatus)
                 .bookmarkCount(0)
                 .build();
@@ -245,7 +244,7 @@ class MissionTest {
                 .missionInfo(missionInfo)
                 .regionId(1L)
                 .citizenId(citizenId)
-                .location(new Point(123456.78, 123456.78))
+                .location(Mission.createPoint(123456.78, 123456.78))
                 .missionStatus(MissionStatus.MATCHING)
                 .bookmarkCount(0)
                 .build();
@@ -276,7 +275,7 @@ class MissionTest {
                                 .build())
                 .regionId(1L)
                 .citizenId(citizenId)
-                .location(new Point(123456.78, 123456.78))
+                .location(Mission.createPoint(123456.78, 123456.78))
                 .missionStatus(MissionStatus.MATCHING)
                 .bookmarkCount(0)
                 .build();

--- a/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionTest.java
+++ b/onedayhero-domain/src/test/java/com/sixheroes/onedayherodomain/mission/MissionTest.java
@@ -71,7 +71,7 @@ class MissionTest {
         var missionDate = LocalDate.of(2023, 10, 20);
         var startTime = LocalTime.of(10, 0, 0);
         var endTime = LocalTime.of(10, 30, 0);
-        var deadlineTime = LocalTime.of(10, 0, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var missionInfo = MissionInfo.builder()
                 .title("수정하는 제목")
@@ -128,7 +128,7 @@ class MissionTest {
         var missionDate = LocalDate.of(2023, 10, 20);
         var startTime = LocalTime.of(10, 0, 0);
         var endTime = LocalTime.of(10, 30, 0);
-        var deadlineTime = LocalTime.of(10, 0, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var missionInfo = MissionInfo.builder()
                 .title("수정하는 제목")
@@ -169,7 +169,7 @@ class MissionTest {
         var missionDate = LocalDate.of(2023, 10, 20);
         var startTime = LocalTime.of(10, 0, 0);
         var endTime = LocalTime.of(10, 30, 0);
-        var deadlineTime = LocalTime.of(10, 0, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var missionInfo = MissionInfo.builder()
                 .title("수정하는 제목")
@@ -219,7 +219,10 @@ class MissionTest {
                                 .missionDate(LocalDate.of(2023, 11, 1))
                                 .startTime(LocalTime.of(12, 30))
                                 .endTime(LocalTime.of(14, 30))
-                                .deadlineTime(LocalTime.of(12, 0))
+                                .deadlineTime(LocalDateTime.of(
+                                        LocalDate.of(2023, 11, 1),
+                                        LocalTime.of(12, 30)
+                                ))
                                 .price(1000)
                                 .serverTime(LocalDateTime.of(
                                         LocalDate.of(2023, 10, 31),
@@ -266,7 +269,10 @@ class MissionTest {
                                 .missionDate(LocalDate.of(2023, 11, 1))
                                 .startTime(LocalTime.of(12, 30))
                                 .endTime(LocalTime.of(14, 30))
-                                .deadlineTime(LocalTime.of(12, 0))
+                                .deadlineTime(LocalDateTime.of(
+                                        LocalDate.of(2023, 11, 1),
+                                        LocalTime.of(12, 0)
+                                ))
                                 .price(1000)
                                 .serverTime(LocalDateTime.of(
                                         LocalDate.of(2023, 10, 31),

--- a/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/mission/MissionQueryRepository.java
+++ b/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/mission/MissionQueryRepository.java
@@ -162,7 +162,7 @@ public class MissionQueryRepository {
     }
 
     private BooleanBuilder missionCategoryIdsIn(List<Long> missionCategories) {
-        if (missionCategories.isEmpty()) {
+        if (missionCategories == null || missionCategories.isEmpty()) {
             return null;
         }
 
@@ -170,7 +170,7 @@ public class MissionQueryRepository {
     }
 
     private BooleanBuilder regionIdsIn(List<Long> regionIds) {
-        if (regionIds.isEmpty()) {
+        if (regionIds == null || regionIds.isEmpty()) {
             return null;
         }
 
@@ -178,7 +178,7 @@ public class MissionQueryRepository {
     }
 
     private BooleanBuilder missionDatesIn(List<LocalDate> missionDates) {
-        if (missionDates.isEmpty()) {
+        if (missionDates == null || missionDates.isEmpty()) {
             return null;
         }
 

--- a/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/mission/response/MissionQueryResponse.java
+++ b/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/mission/response/MissionQueryResponse.java
@@ -6,6 +6,7 @@ import com.sixheroes.onedayherodomain.mission.MissionStatus;
 import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 
 public record MissionQueryResponse(
@@ -42,8 +43,8 @@ public record MissionQueryResponse(
         @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
         LocalTime endTime,
 
-        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "HH:mm", timezone = "Asia/Seoul")
-        LocalTime deadlineTime,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+        LocalDateTime deadlineTime,
 
         Integer price,
 

--- a/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/mission/response/MissionQueryResponse.java
+++ b/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/mission/response/MissionQueryResponse.java
@@ -3,7 +3,7 @@ package com.sixheroes.onedayheroquerydsl.mission.response;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sixheroes.onedayherodomain.mission.MissionCategoryCode;
 import com.sixheroes.onedayherodomain.mission.MissionStatus;
-import org.springframework.data.geo.Point;
+import org.locationtech.jts.geom.Point;
 
 import java.time.LocalDate;
 import java.time.LocalTime;

--- a/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/util/SliceResultConverter.java
+++ b/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/util/SliceResultConverter.java
@@ -8,6 +8,10 @@ import java.util.List;
 
 public final class SliceResultConverter {
 
+    private SliceResultConverter() {
+        
+    }
+
     public static <T> Slice<T> consume(List<T> content, Pageable pageable) {
         boolean hasNext = false;
 

--- a/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/util/SliceResultConverter.java
+++ b/onedayhero-infra-querydsl/src/main/java/com/sixheroes/onedayheroquerydsl/util/SliceResultConverter.java
@@ -1,0 +1,21 @@
+package com.sixheroes.onedayheroquerydsl.util;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+
+import java.util.List;
+
+public final class SliceResultConverter {
+
+    public static <T> Slice<T> consume(List<T> content, Pageable pageable) {
+        boolean hasNext = false;
+
+        if (content.size() > pageable.getPageSize()) {
+            hasNext = true;
+            content.remove(pageable.getPageSize());
+        }
+
+        return new SliceImpl<>(content, pageable, hasNext);
+    }
+}

--- a/onedayhero-infra-querydsl/src/test/java/com/sixheroes/onedayheroinfraquerydsl/mission/MissionQueryRepositoryTest.java
+++ b/onedayhero-infra-querydsl/src/test/java/com/sixheroes/onedayheroinfraquerydsl/mission/MissionQueryRepositoryTest.java
@@ -12,7 +12,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.geo.Point;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDate;
@@ -315,7 +314,7 @@ class MissionQueryRepositoryTest extends IntegrationQueryDslTest {
                 .missionInfo(missionInfo)
                 .regionId(regionId)
                 .citizenId(citizenId)
-                .location(new Point(123456.78, 123456.78))
+                .location(Mission.createPoint(123456.78, 123456.78))
                 .missionStatus(MissionStatus.MATCHING)
                 .bookmarkCount(0)
                 .build();
@@ -333,7 +332,7 @@ class MissionQueryRepositoryTest extends IntegrationQueryDslTest {
                 .missionInfo(missionInfo)
                 .regionId(regionId)
                 .citizenId(citizenId)
-                .location(new Point(123456.78, 123456.78))
+                .location(Mission.createPoint(123456.78, 123456.78))
                 .missionStatus(missionStatus)
                 .bookmarkCount(0)
                 .build();

--- a/onedayhero-infra-querydsl/src/test/java/com/sixheroes/onedayheroinfraquerydsl/mission/MissionQueryRepositoryTest.java
+++ b/onedayhero-infra-querydsl/src/test/java/com/sixheroes/onedayheroinfraquerydsl/mission/MissionQueryRepositoryTest.java
@@ -75,7 +75,7 @@ class MissionQueryRepositoryTest extends IntegrationQueryDslTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var missionInfo = createMissionInfo(missionDate, startTime, endTime, deadlineTime, serverTime);
 
@@ -220,7 +220,7 @@ class MissionQueryRepositoryTest extends IntegrationQueryDslTest {
         var missionDate = LocalDate.of(2023, 10, 10);
         var startTime = LocalTime.of(10, 0);
         var endTime = LocalTime.of(10, 30);
-        var deadlineTime = LocalTime.of(10, 0);
+        var deadlineTime = LocalDateTime.of(missionDate, startTime);
 
         var missionInfo = createMissionInfo(missionDate, startTime, endTime, deadlineTime, serverTime);
         var citizenId = 1L;
@@ -236,6 +236,7 @@ class MissionQueryRepositoryTest extends IntegrationQueryDslTest {
         var savedMission = missionRepository.saveAll(
                 List.of(mission, completedMission, matchedMission, expiredMission)
         );
+
 
         // when
         var missionQueryResponse = missionQueryRepository.findProgressMissionByUserId(pageRequest, citizenId);
@@ -278,7 +279,10 @@ class MissionQueryRepositoryTest extends IntegrationQueryDslTest {
                 .missionDate(missionDate)
                 .startTime(LocalTime.of(10, 0))
                 .endTime(LocalTime.of(10, 30))
-                .deadlineTime(LocalTime.of(10, 0))
+                .deadlineTime(LocalDateTime.of(
+                        missionDate,
+                        LocalTime.of(10, 0)
+                ))
                 .price(10000)
                 .serverTime(serverTime)
                 .build();
@@ -288,7 +292,7 @@ class MissionQueryRepositoryTest extends IntegrationQueryDslTest {
             LocalDate missionDate,
             LocalTime startTime,
             LocalTime endTime,
-            LocalTime deadlineTime,
+            LocalDateTime deadlineTime,
             LocalDateTime serverTime
     ) {
         return MissionInfo.builder()

--- a/scripts/switch.sh
+++ b/scripts/switch.sh
@@ -14,6 +14,6 @@ function switch_proxy() {
     echo "> Port 전환"
     echo "set \$service_url http://43.200.91.152:${IDLE_PORT};" | sudo tee /etc/nginx/conf.d/service-url.inc
 
-    sudo docker exec -d nginx nginx -s reload
     echo "> docker exec -d nginx nginx -s reload"
+    sudo docker exec -d nginx nginx -s reload
 }


### PR DESCRIPTION
## 🖊️ 1. Changes
- SpringFramework.geo의 Point 컬럼에서 문제가 발생하여 `hibernate.spatial` 에서 제공해주는 `org.locationtech.jts.geom.Point`로 변경하였습니다.
- Point를 생성하는 방식이 기존의 geo에서 존재하던 Point와 달라서, Mission 도메인 내부에서 Point를 생성하는 정적 메서드 팩토리를 추가하였습니다.
- 응답 값을 Point를 반환해주는 형식에서 `longitude(경도)`, `latitude(위도)`를 따로 뽑았습니다.
- 반환 타입 중 deadlineTime이 `LocalDateTime` 이여야 하는데, `LocalTime` 이였어서, 해당 부분과 연관 된 부분들을 전체적으로 수정하였습니다.
- Slice 반환 시 offset, limit에 대한 문제를 해결하였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. Spring Boot 3.1.5 버전에서 mysql-connector 라이브 러리에 대해서 spring boot 버전에 맞는 부분을 자동으로 생성해주지 않았습니다.
따라서, mysql-connector에 대한 version을 명시해주었습니다.
2. Spring Boot 3 이후 `org.hibernate.spatial.dialect.mysql.MySQL8SpatialDialect`를 불러오지 못하는 이슈가 있었습니다. 
해당 부분 `org.hibernate.dialect.MySQLDialect` 다음과 같이 명시하여 해결되었습니다. 저걸로 통일되었다고 합니다.
3. Slice 구현 시에는 `PageExecutableUtils` 를 사용 할 필요가 없었습니다.

## 😌 4. To Reviewer

- Slice 구현 시 반환 값을 정해주기 위해서 hasNext()를 반환하는 로직이 많은 QueryRepository에서 사용 할 것으로 생각이 들었습니다. 다음과 같은 유틸성 쿼리를 만들었습니다.
```java
public final class SliceResultConverter {

    public static <T> Slice<T> consume(List<T> content, Pageable pageable) {
        boolean hasNext = false;

        if (content.size() > pageable.getPageSize()) {
            hasNext = true;
            content.remove(pageable.getPageSize());
        }

        return new SliceImpl<>(content, pageable, hasNext);
    }
}
``` 

## ✅ 5. Plans
- [X] - postman을 활용하여 모든 api 정상적으로 동작하는지 테스트

## 🙌 6. Checklist
- [X] - 통합 테스트를 수행해보셨나요?
- [X] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [X] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
