### PR TITLE
[SIX-225] 완료된 미션 조회 api 및 서비스 로직 구현 및 테스트

### DIFF
--- a/onedayhero-api/src/docs/asciidoc/api/mission/mission.adoc
+++ b/onedayhero-api/src/docs/asciidoc/api/mission/mission.adoc
@@ -4,7 +4,7 @@
 ==== HTTP Request
 
 include::{snippets}/mission-create/http-request.adoc[]
-include::{snippets}/mission-create/request-fields.adoc[]
+include::{snippets}/mission-create/request-part-missionCreateRequest-fields.adoc[]
 
 ==== HTTP Response
 
@@ -50,6 +50,19 @@ include::{snippets}/mission-progress-find/http-request.adoc[]
 include::{snippets}/mission-progress-find/http-response.adoc[]
 include::{snippets}/mission-progress-find/response-fields.adoc[]
 
+[[mission-completed-find]]
+=== 유저는 완료된 미션을 조회 할 수 있다.
+
+==== Http Request
+
+include::{snippets}/mission-completed-find/path-parameters.adoc[]
+include::{snippets}/mission-completed-find/http-request.adoc[]
+
+==== Http Response
+
+include::{snippets}/mission-completed-find/http-response.adoc[]
+include::{snippets}/mission-completed-find/response-fields.adoc[]
+
 [[mission-update]]
 === 시민은 미션을 수정 할 수 있다.
 
@@ -57,7 +70,7 @@ include::{snippets}/mission-progress-find/response-fields.adoc[]
 
 include::{snippets}/mission-update/path-parameters.adoc[]
 include::{snippets}/mission-update/http-request.adoc[]
-include::{snippets}/mission-update/request-fields.adoc[]
+include::{snippets}/mission-update/request-part-missionUpdateRequest-fields.adoc[]
 
 ==== HTTP Response
 

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/MissionController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/mission/MissionController.java
@@ -3,6 +3,7 @@ package com.sixheroes.onedayheroapi.mission;
 import com.sixheroes.onedayheroapi.global.response.ApiResponse;
 import com.sixheroes.onedayheroapi.mission.request.*;
 import com.sixheroes.onedayheroapplication.mission.MissionService;
+import com.sixheroes.onedayheroapplication.mission.response.MissionCompletedResponse;
 import com.sixheroes.onedayheroapplication.mission.response.MissionIdResponse;
 import com.sixheroes.onedayheroapplication.mission.response.MissionProgressResponse;
 import com.sixheroes.onedayheroapplication.mission.response.MissionResponse;
@@ -54,6 +55,16 @@ public class MissionController {
             @PathVariable Long userId
     ) {
         var result = missionService.findProgressMission(pageable, userId);
+
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    @GetMapping("/completed/{userId}")
+    public ResponseEntity<ApiResponse<Slice<MissionCompletedResponse>>> findCompletedMission(
+            @PageableDefault(size = 5) Pageable pageable,
+            @PathVariable Long userId
+    ) {
+        var result = missionService.findCompletedMissionByUserId(pageable, userId);
 
         return ResponseEntity.ok(ApiResponse.ok(result));
     }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/MissionReader.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/MissionReader.java
@@ -29,8 +29,11 @@ public class MissionReader {
                 });
     }
 
-    public MissionQueryResponse fetchFindOne(Long missionId) {
-        return missionQueryRepository.fetchOne(missionId)
+    public MissionQueryResponse fetchFindOne(
+            Long missionId,
+            Long userId
+    ) {
+        return missionQueryRepository.fetchOne(missionId, userId)
                 .orElseThrow(() -> {
                     log.debug("존재하지 않는 미션 아이디가 입력되었습니다. id : {}", missionId);
                     return new NoSuchElementException(ErrorCode.EM_008.name());

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/MissionQueryRepository.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/MissionQueryRepository.java
@@ -20,6 +20,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static com.sixheroes.onedayherodomain.mission.QMission.mission;
+import static com.sixheroes.onedayherodomain.mission.QMissionBookmark.missionBookmark;
 import static com.sixheroes.onedayherodomain.mission.QMissionCategory.missionCategory;
 import static com.sixheroes.onedayherodomain.region.QRegion.region;
 
@@ -54,12 +55,15 @@ public class MissionQueryRepository {
                                 mission.missionInfo.deadlineTime,
                                 mission.missionInfo.price,
                                 mission.bookmarkCount,
-                                mission.missionStatus
+                                mission.missionStatus,
+                                missionBookmark.id
                         ))
                 .from(mission)
                 .join(mission.missionCategory, missionCategory)
                 .join(region)
                 .on(region.id.eq(mission.regionId))
+                .leftJoin(missionBookmark)
+                .on(missionBookmark.mission.id.eq(mission.id), missionBookmark.userId.eq(request.userId()))
                 .where(userIdEq(request.userId()),
                         missionCategoryIdsIn(request.missionCategoryIds()),
                         regionIdsIn(request.regionIds()),
@@ -85,12 +89,15 @@ public class MissionQueryRepository {
                         region.dong,
                         mission.missionInfo.missionDate,
                         mission.bookmarkCount,
-                        mission.missionStatus
+                        mission.missionStatus,
+                        missionBookmark.id
                 ))
                 .from(mission)
                 .join(mission.missionCategory, missionCategory)
                 .join(region)
                 .on(mission.regionId.eq(region.id))
+                .leftJoin(missionBookmark)
+                .on(missionBookmark.mission.id.eq(mission.id), missionBookmark.userId.eq(userId))
                 .where(userIdEq(userId), missionStatusIsProgress())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)
@@ -99,7 +106,8 @@ public class MissionQueryRepository {
     }
 
     public Optional<MissionQueryResponse> fetchOne(
-            Long missionId
+            Long missionId,
+            Long userId
     ) {
         var queryResult = queryFactory.select(Projections.constructor(MissionQueryResponse.class,
                         mission.id,
@@ -120,12 +128,15 @@ public class MissionQueryRepository {
                         mission.missionInfo.deadlineTime,
                         mission.missionInfo.price,
                         mission.bookmarkCount,
-                        mission.missionStatus
+                        mission.missionStatus,
+                        missionBookmark.id
                 ))
                 .from(mission)
                 .join(mission.missionCategory, missionCategory)
                 .join(region)
                 .on(region.id.eq(mission.regionId))
+                .leftJoin(missionBookmark)
+                .on(missionBookmark.mission.id.eq(mission.id), missionBookmark.userId.eq(userId))
                 .where(mission.id.eq(missionId))
                 .fetchOne();
 
@@ -147,12 +158,15 @@ public class MissionQueryRepository {
                         region.dong,
                         mission.missionInfo.missionDate,
                         mission.bookmarkCount,
-                        mission.missionStatus
+                        mission.missionStatus,
+                        missionBookmark.id
                 ))
                 .from(mission)
                 .join(mission.missionCategory, missionCategory)
                 .join(region)
                 .on(mission.regionId.eq(region.id))
+                .leftJoin(missionBookmark)
+                .on(missionBookmark.mission.id.eq(mission.id), missionBookmark.userId.eq(userId))
                 .where(userIdEq(userId), missionStatusIsCompleted())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize() + 1)

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/response/MissionCompletedQueryResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/response/MissionCompletedQueryResponse.java
@@ -28,6 +28,8 @@ public record MissionCompletedQueryResponse(
 
         Integer bookmarkCount,
 
-        MissionStatus missionStatus
+        MissionStatus missionStatus,
+
+        Long bookmarkId
 ) {
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/response/MissionCompletedQueryResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/response/MissionCompletedQueryResponse.java
@@ -1,0 +1,33 @@
+package com.sixheroes.onedayheroapplication.mission.repository.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sixheroes.onedayherodomain.mission.MissionCategoryCode;
+import com.sixheroes.onedayherodomain.mission.MissionStatus;
+
+import java.time.LocalDate;
+
+public record MissionCompletedQueryResponse(
+        Long id,
+
+        String title,
+
+        Long categoryId,
+
+        MissionCategoryCode categoryCode,
+
+        String categoryName,
+
+        String si,
+
+        String gu,
+
+        String dong,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate missionDate,
+
+        Integer bookmarkCount,
+
+        MissionStatus missionStatus
+) {
+}

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/response/MissionProgressQueryResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/response/MissionProgressQueryResponse.java
@@ -28,6 +28,8 @@ public record MissionProgressQueryResponse(
 
         Integer bookmarkCount,
 
-        MissionStatus missionStatus
+        MissionStatus missionStatus,
+
+        Long bookmarkId
 ) {
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/response/MissionQueryResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/repository/response/MissionQueryResponse.java
@@ -50,6 +50,8 @@ public record MissionQueryResponse(
 
         Integer bookmarkCount,
 
-        MissionStatus missionStatus
+        MissionStatus missionStatus,
+
+        Long bookmarkId
 ) {
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCategoryResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCategoryResponse.java
@@ -1,5 +1,6 @@
 package com.sixheroes.onedayheroapplication.mission.response;
 
+import com.sixheroes.onedayheroapplication.mission.repository.response.MissionCompletedQueryResponse;
 import com.sixheroes.onedayheroapplication.mission.repository.response.MissionProgressQueryResponse;
 import com.sixheroes.onedayheroapplication.mission.repository.response.MissionQueryResponse;
 import com.sixheroes.onedayherodomain.mission.MissionCategory;
@@ -24,6 +25,16 @@ public record MissionCategoryResponse(
 
     public static MissionCategoryResponse from(
             MissionProgressQueryResponse response
+    ) {
+        return MissionCategoryResponse.builder()
+                .id(response.categoryId())
+                .code(response.categoryCode().name())
+                .name(response.categoryName())
+                .build();
+    }
+
+    public static MissionCategoryResponse from(
+            MissionCompletedQueryResponse response
     ) {
         return MissionCategoryResponse.builder()
                 .id(response.categoryId())

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCompletedResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCompletedResponse.java
@@ -1,0 +1,45 @@
+package com.sixheroes.onedayheroapplication.mission.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sixheroes.onedayheroapplication.mission.repository.response.MissionCompletedQueryResponse;
+import lombok.Builder;
+
+import java.time.LocalDate;
+
+@Builder
+public record MissionCompletedResponse(
+        Long id,
+
+        String title,
+
+        MissionCategoryResponse missionCategory,
+
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd", timezone = "Asia/Seoul")
+        LocalDate missionDate,
+
+        Integer bookmarkCount,
+
+        String missionStatus,
+
+        String imagePath,
+
+        boolean isBookmarked
+) {
+
+    public static MissionCompletedResponse from(
+            MissionCompletedQueryResponse response,
+            String imagePath,
+            boolean isBookmarked
+    ) {
+        return MissionCompletedResponse.builder()
+                .id(response.id())
+                .title(response.title())
+                .missionCategory(MissionCategoryResponse.from(response))
+                .missionDate(response.missionDate())
+                .bookmarkCount(response.bookmarkCount())
+                .missionStatus(response.missionStatus().name())
+                .imagePath(imagePath)
+                .isBookmarked(isBookmarked)
+                .build();
+    }
+}

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionQueryRepositoryTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/mission/MissionQueryRepositoryTest.java
@@ -27,6 +27,7 @@ class MissionQueryRepositoryTest extends IntegrationQueryDslTest {
     void findOneWithFetchJoin() {
         // given
         var missionCategory = missionCategoryRepository.findById(1L).get();
+        var citizenId = 1L;
 
         var serverTime = LocalDateTime.of(LocalDate.of(2023, 10, 9), LocalTime.MIDNIGHT);
 
@@ -42,7 +43,7 @@ class MissionQueryRepositoryTest extends IntegrationQueryDslTest {
         var savedMission = missionRepository.save(mission);
 
         // when
-        var missionQueryResponse = missionQueryRepository.fetchOne(savedMission.getId());
+        var missionQueryResponse = missionQueryRepository.fetchOne(savedMission.getId(), citizenId);
 
         // then
         assertThat(missionQueryResponse).isNotEmpty();


### PR DESCRIPTION
## 🖊️ 1. Changes
- 완료된 미션을 조회하는 api 및 서비스 로직을 구현하고 테스트를 진행하였습니다.
- 테스트를 만드는 과정에서 이전에 빠른 api 전송을 위해 누락 된 진행중인 미션 조회에 대한 서비스 로직을 추가하였습니다.
----
- 형진님의 코드 리뷰를 토대로 쿼리 성능을 최적화하였습니다. 최적화 이전의 쿼리 발생은 다음과 같습니다.
1. Slice로 10개의 미션을 가지고 온다.
2. 10개의 미션에 대한 사진을 가지고 온다. 
3. 10개의 미션에 대해서 bookmark가 되어있는 상태인지 확인한다.
총 10 + 10 + 10 으로 약 30개의 쿼리가 발생을 하게 됩니다. 만약 DB에 데이터가 10만개가 있었다면 missionId와 userId가 인덱싱 되어있지 않았다면 10개를 찾는데 더 많은 시간을 할애했을 것으로 판단됩니다.
- 쿼리의 변경 이후 3번 과정이 빠지게 되었습니다. 다만, leftJoin을 사용하기에 인덱싱 처리가 어떻게 될지가 의문이긴합니다.
-> 해당 부분 nGrinder로 테스트 해보고 말씀드리겠습니다

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
5. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans

## 🙌 6. Checklist
- [X] - 통합 테스트를 수행해보셨나요?
- [X] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [X] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
