### PR TITLE
[SIX-153] SSE 구독, 알림 조회, 알림 삭제

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+onedayhero

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="PREFERRED_PROJECT_CODE_STYLE" value="Default" />
+  </state>
+</component>

--- a/onedayhero-api/src/docs/asciidoc/api/alarm/alarm.adoc
+++ b/onedayhero-api/src/docs/asciidoc/api/alarm/alarm.adoc
@@ -1,0 +1,26 @@
+[[alarm-find]]
+=== 알림 조회
+
+==== HTTP Request
+
+include::{snippets}/alarm-find/http-request.adoc[]
+include::{snippets}/alarm-find/request-headers.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/alarm-find/http-response.adoc[]
+include::{snippets}/alarm-find/response-fields.adoc[]
+
+[[alarm-delete]]
+=== 알림 삭제
+
+==== HTTP Request
+
+include::{snippets}/alarm-delete/http-request.adoc[]
+include::{snippets}/alarm-delete/request-headers.adoc[]
+include::{snippets}/alarm-delete/path-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/alarm-delete/http-response.adoc[]
+include::{snippets}/alarm-delete/response-fields.adoc[]

--- a/onedayhero-api/src/docs/asciidoc/api/sse/sse.adoc
+++ b/onedayhero-api/src/docs/asciidoc/api/sse/sse.adoc
@@ -1,0 +1,11 @@
+[[sse-subscribe]]
+=== SSE 구독
+
+==== HTTP Request
+
+include::{snippets}/sse-subscribe/http-request.adoc[]
+include::{snippets}/sse-subscribe/request-headers.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/sse-subscribe/http-response.adoc[]

--- a/onedayhero-api/src/docs/asciidoc/index.adoc
+++ b/onedayhero-api/src/docs/asciidoc/index.adoc
@@ -43,3 +43,13 @@ include::api/missionproposal/missionproposal.adoc[]
 == Review API
 
 include::api/review/review.adoc[]
+
+[[SSE-API]]
+== SSE API
+
+include::api/sse/sse.adoc[]
+
+[[Alarm-API]]
+== Alarm API
+
+include::api/alarm/alarm.adoc[]

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/alarm/AlarmController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/alarm/AlarmController.java
@@ -1,0 +1,41 @@
+package com.sixheroes.onedayheroapi.alarm;
+
+import com.sixheroes.onedayheroapi.global.argumentsresolver.authuser.AuthUser;
+import com.sixheroes.onedayheroapi.global.response.ApiResponse;
+import com.sixheroes.onedayheroapplication.alarm.AlarmService;
+import com.sixheroes.onedayheroapplication.alarm.response.AlarmResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/alarms")
+@RestController
+public class AlarmController {
+
+    private final AlarmService alarmService;
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Slice<AlarmResponse>>> findAlarm(
+        @AuthUser Long userId,
+        @PageableDefault Pageable pageable
+    ) {
+        var alarm = alarmService.findAlarm(userId, pageable);
+
+        return ResponseEntity.ok(ApiResponse.ok(alarm));
+    }
+
+    @DeleteMapping("/{alarmId}")
+    public ResponseEntity<ApiResponse<Void>> deleteAlarm(
+        @AuthUser Long userId,
+        @PathVariable String alarmId
+    ) {
+        alarmService.deleteAlarm(userId, alarmId);
+
+        return new ResponseEntity<>(ApiResponse.noContent(), HttpStatus.NO_CONTENT);
+    }
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseController.java
@@ -1,0 +1,29 @@
+package com.sixheroes.onedayheroapi.sse;
+
+import com.sixheroes.onedayheroapi.global.argumentsresolver.authuser.AuthUser;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/sse/")
+@RestController
+public class SseController {
+
+    private static final String DUMMY_DATA_NAME = "success";
+    private static final String DUMMY_DATA = "Sse subscribe success";
+    private final SseEmitters sseEmitters;
+
+    @GetMapping(value = "/subscribe", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public ResponseEntity<SseEmitter> subscribe(
+        @AuthUser Long userId
+    ) {
+        var sseEmitter = sseEmitters.add(userId);
+        sseEmitters.send(userId, DUMMY_DATA_NAME, DUMMY_DATA);
+        return ResponseEntity.ok(sseEmitter);
+    }
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/sse/")
+@RequestMapping("/api/v1/sse")
 @RestController
 public class SseController {
 

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEmitters.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEmitters.java
@@ -19,11 +19,11 @@ public class SseEmitters {
         SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
         this.emitters.put(userId, emitter);
         emitter.onTimeout(() -> {
-            log.info("onTimeout callback");
+            log.warn("onTimeout callback");
             emitter.complete();
         });
         emitter.onCompletion(() -> {
-            log.info("onCompletion callback");
+            log.warn("onCompletion callback");
             this.emitters.remove(userId);
         });
         return emitter;

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEmitters.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEmitters.java
@@ -1,0 +1,57 @@
+package com.sixheroes.onedayheroapi.sse;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Slf4j
+@Component
+public class SseEmitters {
+
+    private static final Long DEFAULT_TIMEOUT = 30 * 60 * 1000L; // 30분
+    private final Map<Long, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    public SseEmitter add(Long userId) {
+        SseEmitter emitter = new SseEmitter(DEFAULT_TIMEOUT);
+        this.emitters.put(userId, emitter);
+        emitter.onTimeout(() -> {
+            log.info("onTimeout callback");
+            emitter.complete();
+        });
+        emitter.onCompletion(() -> {
+            log.info("onCompletion callback");
+            this.emitters.remove(userId);
+        });
+        return emitter;
+    }
+
+    public void send(
+        Long userId,
+        String name,
+        Object data
+    ) {
+        var sseEmitter = get(userId);
+        try {
+            sseEmitter.send(SseEmitter.event()
+                .name(name)
+                .data(data)
+            );
+        } catch (IOException e) {
+            log.error("SSE를 보내는 과정에서 오류가 발생했습니다.");
+        }
+    }
+
+    private SseEmitter get(
+        Long userId
+    ) {
+        var sseEmitter = emitters.get(userId);
+        if (sseEmitter == null) {
+            log.debug("SSE를 구독하지 않은 유저입니다. userId : {}", userId);
+        }
+        return sseEmitter;
+    }
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEventListener.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEventListener.java
@@ -1,0 +1,22 @@
+package com.sixheroes.onedayheroapi.sse;
+
+import com.sixheroes.onedayheroapplication.alarm.dto.SsePaylod;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.event.EventListener;
+
+@Slf4j
+@RequiredArgsConstructor
+public class SseEventListener {
+
+    private final SseEmitters sseEmitters;
+
+    @EventListener
+    public void sendSseEmitter(SsePaylod ssePaylod) {
+        sseEmitters.send(
+            ssePaylod.userId(),
+            "alarm",
+            ssePaylod.data()
+        );
+    }
+}

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/alarm/AlarmControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/alarm/AlarmControllerTest.java
@@ -1,0 +1,227 @@
+package com.sixheroes.onedayheroapi.alarm;
+
+import com.sixheroes.onedayheroapi.docs.RestDocsSupport;
+import com.sixheroes.onedayheroapplication.alarm.AlarmService;
+import com.sixheroes.onedayheroapplication.alarm.response.AlarmResponse;
+import com.sixheroes.onedayherocommon.converter.DateTimeConverter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.payload.JsonFieldType;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.UUID;
+
+import static com.sixheroes.onedayheroapi.docs.DocumentFormatGenerator.getDateTimeFormat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doNothing;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath;
+import static org.springframework.restdocs.payload.PayloadDocumentation.responseFields;
+import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AlarmController.class)
+class AlarmControllerTest extends RestDocsSupport {
+
+    @MockBean
+    private AlarmService alarmService;
+
+    @Override
+    protected Object setController() {
+        return new AlarmController(alarmService);
+    }
+
+    @DisplayName("특정 유저의 알람을 최신 순으로 조회한다.")
+    @Test
+    void findAll() throws Exception {
+        // given
+        var alarmResponses = createdAlarm();
+        var pageRequest = PageRequest.of(1, 4);
+
+        var slice = new SliceImpl<AlarmResponse>(alarmResponses, pageRequest, true);
+
+        given(alarmService.findAlarm(anyLong(), any(Pageable.class))).willReturn(slice);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/alarms")
+            .header(HttpHeaders.AUTHORIZATION, getAccessToken())
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.data").exists())
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.data.content[0].id").value(alarmResponses.get(0).id()))
+            .andExpect(jsonPath("$.data.content[0].title").value(alarmResponses.get(0).title()))
+            .andExpect(jsonPath("$.data.content[0].content").value(alarmResponses.get(0).content()))
+            .andExpect(jsonPath("$.data.content[0].createdAt").value(DateTimeConverter.convertLocalDateTimeToString(alarmResponses.get(0).createdAt())))
+            .andExpect(jsonPath("$.data.pageable.pageNumber").value(slice.getPageable().getPageNumber()))
+            .andExpect(jsonPath("$.data.pageable.pageSize").value(slice.getPageable().getPageSize()))
+            .andExpect(jsonPath("$.data.pageable.sort.empty").value(slice.getPageable().getSort().isEmpty()))
+            .andExpect(jsonPath("$.data.pageable.offset").value(slice.getPageable().getOffset()))
+            .andExpect(jsonPath("$.data.pageable.paged").value(slice.getPageable().isPaged()))
+            .andExpect(jsonPath("$.data.pageable.unpaged").value(slice.getPageable().isUnpaged()))
+            .andExpect(jsonPath("$.data.size").value(slice.getSize()))
+            .andExpect(jsonPath("$.data.number").value(slice.getNumber()))
+            .andExpect(jsonPath("$.data.sort.empty").value(slice.getSort().isEmpty()))
+            .andExpect(jsonPath("$.data.sort.sorted").value(slice.getSort().isSorted()))
+            .andExpect(jsonPath("$.data.sort.unsorted").value(slice.getSort().isUnsorted()))
+            .andExpect(jsonPath("$.data.numberOfElements").value(slice.getNumberOfElements()))
+            .andExpect(jsonPath("$.data.first").value(slice.isFirst()))
+            .andExpect(jsonPath("$.data.last").value(slice.isLast()))
+            .andExpect(jsonPath("$.data.empty").value(slice.isEmpty()))
+            .andExpect(jsonPath("$.serverDateTime").exists())
+            .andDo(document("alarm-find",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("Authorization: Bearer 액세스토큰")
+                ),
+                queryParameters(
+                    parameterWithName("page").optional()
+                        .description("페이지 번호"),
+                    parameterWithName("size").optional()
+                        .description("데이터 크기")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(JsonFieldType.NUMBER)
+                        .description("HTTP 응답 코드"),
+                    fieldWithPath("data").type(JsonFieldType.OBJECT)
+                        .description("응답 데이터"),
+                    fieldWithPath("data.content[]").type(JsonFieldType.ARRAY)
+                        .description("알람 응답 데이터 배열"),
+                    fieldWithPath("data.content[].id").type(JsonFieldType.STRING)
+                        .description("알람 ID"),
+                    fieldWithPath("data.content[].title").type(JsonFieldType.STRING)
+                        .description("알람 제목"),
+                    fieldWithPath("data.content[].content")
+                        .description("알람 내용"),
+                    fieldWithPath("data.content[].createdAt")
+                        .description("알림 생성 시간"),
+                    fieldWithPath("data.pageable.pageNumber").type(JsonFieldType.NUMBER)
+                        .description("현재 페이지 번호"),
+                    fieldWithPath("data.pageable.pageSize").type(JsonFieldType.NUMBER)
+                        .description("페이지 크기"),
+                    fieldWithPath("data.pageable.sort").type(JsonFieldType.OBJECT)
+                        .description("정렬 상태 객체"),
+                    fieldWithPath("data.pageable.sort.empty").type(JsonFieldType.BOOLEAN)
+                        .description("정렬 정보가 비어있는지 여부"),
+                    fieldWithPath("data.pageable.sort.sorted").type(JsonFieldType.BOOLEAN)
+                        .description("정렬 정보가 있는지 여부"),
+                    fieldWithPath("data.pageable.sort.unsorted").type(JsonFieldType.BOOLEAN)
+                        .description("정렬 정보가 정렬되지 않은지 여부"),
+                    fieldWithPath("data.pageable.offset").type(JsonFieldType.NUMBER)
+                        .description("페이지 번호"),
+                    fieldWithPath("data.pageable.paged").type(JsonFieldType.BOOLEAN)
+                        .description("페이징이 되어 있는지 여부"),
+                    fieldWithPath("data.pageable.unpaged").type(JsonFieldType.BOOLEAN)
+                        .description("페이징이 되어 있지 않은지 여부"),
+                    fieldWithPath("data.size").type(JsonFieldType.NUMBER)
+                        .description("알람 리스트 크기"),
+                    fieldWithPath("data.number").type(JsonFieldType.NUMBER)
+                        .description("현재 페이지 번호"),
+                    fieldWithPath("data.sort").type(JsonFieldType.OBJECT)
+                        .description("알람 리스트 정렬 정보 객체"),
+                    fieldWithPath("data.sort.empty").type(JsonFieldType.BOOLEAN)
+                        .description("알람 리스트의 정렬 정보가 비어있는지 여부"),
+                    fieldWithPath("data.sort.sorted").type(JsonFieldType.BOOLEAN)
+                        .description("알람 리스트의 정렬 정보가 있는지 여부"),
+                    fieldWithPath("data.sort.unsorted").type(JsonFieldType.BOOLEAN)
+                        .description("알람 리스트의 정렬 정보가 정렬되지 않은지 여부"),
+                    fieldWithPath("data.numberOfElements").type(JsonFieldType.NUMBER)
+                        .description("현재 페이지의 요소 수"),
+                    fieldWithPath("data.first").type(JsonFieldType.BOOLEAN)
+                        .description("첫 번째 페이지인지 여부"),
+                    fieldWithPath("data.last").type(JsonFieldType.BOOLEAN)
+                        .description("마지막 페이지인지 여부"),
+                    fieldWithPath("data.empty").type(JsonFieldType.BOOLEAN)
+                        .description("알람 리스트가 비어있는지 여부"),
+                    fieldWithPath("serverDateTime").type(JsonFieldType.STRING)
+                        .attributes(getDateTimeFormat())
+                        .description("서버 응답 시간")
+                )
+            ));
+    }
+
+    @DisplayName("알람을 삭제한다")
+    @Test
+    void deleteAlarm() throws Exception {
+        // given
+        var alarmId = UUID.randomUUID().toString();
+
+        doNothing().when(alarmService).deleteAlarm(anyLong(), anyString());
+
+        // when
+        mockMvc.perform(delete("/api/v1/alarms/{alarmId}", alarmId)
+            .header(HttpHeaders.AUTHORIZATION, getAccessToken())
+            .contentType(MediaType.APPLICATION_JSON))
+            .andDo(print())
+            .andExpect(status().isNoContent())
+            .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(jsonPath("$.status").value(204))
+            .andExpect(jsonPath("$.serverDateTime").exists())
+            .andDo(document("alarm-delete",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("Authorization: Bearer 액세스토큰")
+                ),
+                pathParameters(
+                    parameterWithName("alarmId").description("알람 아이디")
+                ),
+                responseFields(
+                    fieldWithPath("status").type(JsonFieldType.NUMBER)
+                        .description("HTTP 응답 코드"),
+                    fieldWithPath("data").type(JsonFieldType.NULL)
+                        .description("응답 데이터"),
+                    fieldWithPath("serverDateTime").type(JsonFieldType.STRING)
+                        .attributes(getDateTimeFormat())
+                        .description("서버 응답 시간")
+                )
+            ));
+    }
+
+    private List<AlarmResponse> createdAlarm() {
+        var time = LocalDateTime.of(2023, 11, 21, 12, 0, 0);
+
+        var alarmResponse1 = AlarmResponse.builder()
+            .id(UUID.randomUUID().toString())
+            .title("알림 제목")
+            .content("알림 내용")
+            .createdAt(time)
+            .build();
+
+        var alarmResponse2 = AlarmResponse.builder()
+            .id(UUID.randomUUID().toString())
+            .title("알림 제목")
+            .content("알림 내용")
+            .createdAt(time.minusHours(2))
+            .build();
+
+        var alarmResponse3 = AlarmResponse.builder()
+            .id(UUID.randomUUID().toString())
+            .title("알림 제목")
+            .content("알림 내용")
+            .createdAt(time.minusDays(1))
+            .build();
+
+        var alarmResponse4 = AlarmResponse.builder()
+            .id(UUID.randomUUID().toString())
+            .title("알림 제목")
+            .content("알림 내용")
+            .createdAt(time.minusWeeks(1))
+            .build();
+
+        return List.of(alarmResponse1, alarmResponse2, alarmResponse3, alarmResponse4);
+    }
+}

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
@@ -47,6 +47,8 @@ public abstract class RestDocsSupport {
                         .withResponseDefaults(prettyPrint()))
                 .setCustomArgumentResolvers(new PageableHandlerMethodArgumentResolver(), new AuthUserArgumentResolver(jwtProperties))
                 .addMappedInterceptors(new String[]{
+                        "/api/v1/alarms/**",
+                        "/api/v1/sse/**",
                         "/api/v1/chat-rooms/users",
                         "/api/v1/chat-rooms/*/exit",
                         "/api/v1/mission-proposals/**",

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/sse/SseControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/sse/SseControllerTest.java
@@ -1,0 +1,53 @@
+package com.sixheroes.onedayheroapi.sse;
+
+import com.sixheroes.onedayheroapi.docs.RestDocsSupport;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
+import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
+import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
+import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(SseController.class)
+class SseControllerTest extends RestDocsSupport {
+
+    @MockBean
+    private SseEmitters sseEmitters;
+
+    @Override
+    protected Object setController() {
+        return new SseController(sseEmitters);
+    }
+
+    @DisplayName("SSE를 구독한다.")
+    @Test
+    void subscribe() throws Exception {
+        // given
+        var defaultTimeOut = 30 * 60 * 1000L;
+        var sseEmitter = new SseEmitter(defaultTimeOut);
+
+        given(sseEmitters.add(anyLong())).willReturn(sseEmitter);
+
+        // when & then
+        mockMvc.perform(get("/api/v1/sse/subscribe")
+            .header(HttpHeaders.AUTHORIZATION, getAccessToken())
+            .contentType(MediaType.TEXT_EVENT_STREAM))
+            .andDo(print())
+            .andExpect(status().isOk())
+            .andDo(document("sse-subscribe",
+                requestHeaders(
+                    headerWithName(HttpHeaders.AUTHORIZATION).description("Authorization: Bearer 액세스토큰")
+                )
+            ));
+    }
+}

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/sse/SseEmittersTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/sse/SseEmittersTest.java
@@ -1,0 +1,24 @@
+package com.sixheroes.onedayheroapi.sse;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SseEmittersTest {
+
+    @DisplayName("SseEmitter를 추가한다.")
+    @Test
+    void addSseEmitter() {
+        // given
+        var sseEmitters = new SseEmitters();
+        var userId = 1L;
+        var defaultTimeOut = 30 * 60 * 1000L;
+
+        // when
+        var sseEmitter = sseEmitters.add(userId);
+
+        // then
+        assertThat(sseEmitter.getTimeout()).isEqualTo(defaultTimeOut);
+    }
+}

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/alarm/AlarmReader.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/alarm/AlarmReader.java
@@ -1,0 +1,32 @@
+package com.sixheroes.onedayheroapplication.alarm;
+
+import com.sixheroes.onedayherocommon.error.ErrorCode;
+import com.sixheroes.onedayheromongo.alarm.Alarm;
+import com.sixheroes.onedayheromongo.alarm.mongo.AlarmRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
+import org.springframework.stereotype.Component;
+
+import java.util.NoSuchElementException;
+
+@RequiredArgsConstructor
+@Component
+public class AlarmReader {
+
+    private final AlarmRepository alarmRepository;
+
+    public Slice<Alarm> findAll(
+        Long userId,
+        Pageable pageable
+    ) {
+        return alarmRepository.findAllByUserId(userId, pageable);
+    }
+
+    public Alarm findOne(
+        String alarmId
+    ) {
+        return alarmRepository.findById(alarmId)
+            .orElseThrow(() -> new NoSuchElementException(ErrorCode.T_001.name()));
+    }
+}

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/alarm/AlarmService.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/alarm/AlarmService.java
@@ -2,9 +2,12 @@ package com.sixheroes.onedayheroapplication.alarm;
 
 import com.sixheroes.onedayheroapplication.alarm.dto.AlarmPayload;
 import com.sixheroes.onedayheroapplication.alarm.dto.SsePaylod;
+import com.sixheroes.onedayheroapplication.alarm.response.AlarmResponse;
 import com.sixheroes.onedayheromongo.alarm.mongo.AlarmRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
@@ -14,6 +17,8 @@ public class AlarmService {
     private final AlarmRepository alarmRepository;
 
     private final AlarmTemplateReader alarmTemplateReader;
+
+    private final AlarmReader alarmReader;
 
     private final ApplicationEventPublisher applicationEventPublisher;
 
@@ -27,5 +32,25 @@ public class AlarmService {
         alarmRepository.save(alarm);
 
         applicationEventPublisher.publishEvent(SsePaylod.of(alarmType, alarm));
+    }
+
+    public Slice<AlarmResponse> findAlarm(
+        Long userId,
+        Pageable pageable
+    ) {
+        var alarms = alarmReader.findAll(userId, pageable);
+
+        return alarms.map(AlarmResponse::from);
+    }
+
+    public void deleteAlarm(
+        Long userId,
+        String alarmId
+    ) {
+        var alarm = alarmReader.findOne(alarmId);
+
+        alarm.validOwner(userId);
+
+        alarmRepository.delete(alarm);
     }
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/alarm/response/AlarmResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/alarm/response/AlarmResponse.java
@@ -1,0 +1,31 @@
+package com.sixheroes.onedayheroapplication.alarm.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.sixheroes.onedayheromongo.alarm.Alarm;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record AlarmResponse(
+    String id,
+
+    String title,
+
+    String content,
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss", timezone = "Asia/Seoul")
+    LocalDateTime createdAt
+) {
+
+    public static AlarmResponse from(
+        Alarm alarm
+    ) {
+        return AlarmResponse.builder()
+            .id(alarm.getId())
+            .title(alarm.getTitle())
+            .content(alarm.getContent())
+            .createdAt(alarm.getCreatedAt())
+            .build();
+    }
+}

--- a/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/alarm/Alarm.java
+++ b/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/alarm/Alarm.java
@@ -1,12 +1,16 @@
 package com.sixheroes.onedayheromongo.alarm;
 
+import com.sixheroes.onedayherocommon.error.ErrorCode;
+import com.sixheroes.onedayheromongo.global.BaseDocument;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.mongodb.core.mapping.*;
 
+import java.util.Objects;
+
 @Getter
 @Document(collection = "alarms")
-public class Alarm {
+public class Alarm extends BaseDocument {
 
     @MongoId
     @Field(name = "_id", targetType = FieldType.OBJECT_ID)
@@ -36,5 +40,13 @@ public class Alarm {
         this.userId = userId;
         this.title = title;
         this.content = content;
+    }
+
+    public void validOwner(
+        Long userId
+    ) {
+        if (!Objects.equals(this.userId, userId)) {
+            throw new IllegalArgumentException(ErrorCode.T_001.name());
+        }
     }
 }

--- a/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/alarm/AlarmTemplate.java
+++ b/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/alarm/AlarmTemplate.java
@@ -1,5 +1,6 @@
 package com.sixheroes.onedayheromongo.alarm;
 
+import com.sixheroes.onedayheromongo.global.BaseDocument;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.data.mongodb.core.mapping.Document;
@@ -9,7 +10,7 @@ import org.springframework.data.mongodb.core.mapping.MongoId;
 
 @Getter
 @Document(collection = "alarm_templates")
-public class AlarmTemplate {
+public class AlarmTemplate extends BaseDocument {
 
     @MongoId
     @Field(name = "_id", targetType = FieldType.OBJECT_ID)

--- a/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/alarm/mongo/AlarmRepository.java
+++ b/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/alarm/mongo/AlarmRepository.java
@@ -1,7 +1,13 @@
 package com.sixheroes.onedayheromongo.alarm.mongo;
 
 import com.sixheroes.onedayheromongo.alarm.Alarm;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.mongodb.repository.MongoRepository;
+import org.springframework.data.mongodb.repository.Query;
 
 public interface AlarmRepository extends MongoRepository<Alarm, String> {
+
+    @Query(value = "{'user_id' : ?0}", sort = "{'created_at' :  -1}")
+    Slice<Alarm> findAllByUserId(Long userId, Pageable pageable);
 }

--- a/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/global/BaseDocument.java
+++ b/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/global/BaseDocument.java
@@ -1,0 +1,20 @@
+package com.sixheroes.onedayheromongo.global;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.mongodb.core.mapping.Field;
+
+import java.time.LocalDateTime;
+
+@Getter
+public abstract class BaseDocument {
+
+    @CreatedDate
+    @Field("created_at")
+    protected LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Field("updated_at")
+    protected LocalDateTime updatedAt;
+}

--- a/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/global/configuration/MongoConfiguration.java
+++ b/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/global/configuration/MongoConfiguration.java
@@ -1,0 +1,9 @@
+package com.sixheroes.onedayheromongo.global.configuration;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.mongodb.config.EnableMongoAuditing;
+
+@EnableMongoAuditing
+@Configuration
+public class MongoConfiguration {
+}

--- a/onedayhero-mongo/src/test/java/com/sixheroes/onedayheromongo/alarm/mongo/AlarmRepositoryTest.java
+++ b/onedayhero-mongo/src/test/java/com/sixheroes/onedayheromongo/alarm/mongo/AlarmRepositoryTest.java
@@ -1,0 +1,66 @@
+package com.sixheroes.onedayheromongo.alarm.mongo;
+
+import com.sixheroes.onedayheromongo.IntegrationMongoRepositoryTest;
+import com.sixheroes.onedayheromongo.alarm.Alarm;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
+
+import java.util.Comparator;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Disabled
+class AlarmRepositoryTest extends IntegrationMongoRepositoryTest {
+
+    @Autowired
+    private AlarmRepository alarmRepository;
+
+    @AfterEach
+    void teardown() {
+        alarmRepository.deleteAll();
+    }
+
+    @DisplayName("알람 타입으로 알림 템플릿을 찾는다")
+    @Test
+    void findByAlarmType() {
+        // given
+        var alarms = createAlarms();
+        alarmRepository.saveAll(alarms);
+
+        var pageRequest = PageRequest.of(0, 3);
+
+        // when
+        var findAlarms = alarmRepository.findAllByUserId(1L, pageRequest);
+
+        // then
+        assertThat(findAlarms.getContent()).hasSize(3);
+        assertThat(findAlarms.getContent()).isSortedAccordingTo(Comparator.comparing(Alarm::getCreatedAt).reversed());
+    }
+
+    private List<Alarm> createAlarms() {
+        var alarm1 = Alarm.builder()
+            .userId(1L)
+            .title("알림 제목1")
+            .content("알림 내용1")
+            .build();
+
+        var alarm2 = Alarm.builder()
+            .userId(1L)
+            .title("알림 제목2")
+            .content("알림 내용2")
+            .build();
+
+        var alarm3 = Alarm.builder()
+            .userId(1L)
+            .title("알림 제목3")
+            .content("알림 내용3")
+            .build();
+
+        return List.of(alarm1, alarm2, alarm3);
+    }
+}


### PR DESCRIPTION
## 🖊️ 1. Changes

- SSE 구독에 대한 API 구현 및 RestDocs 작성
- 알림 조회 및 삭제에 대한 API 구현 및 RestDocs 작성
- 알림 조회 및 삭제에 대한 비즈니스 로직 구현

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. SseEmitter는 SSE 통신 요청이 들어오면서 생성된 객체로 send를 해야합니다. 따라서 외부 스토리지에 저장할 수 없고 서버 메모리에 저장합니다. 
2. AlarmService가 의존하고 있는 AlarmRepository, AlarmTemplateRepository는 mongo repository입니다. 따라서 mockbean으로  테스트를 수행해야하는데, 개발자가 반환값을 제어하는 의미없는 통합테스트같아 작성하지 않았습니다. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans
- [ ] - 내부 도메인 로직에 알림 보내는 이벤트 발행
- [ ] - 

## 🙌 6. Checklist
- [x] - 통합 테스트를 수행해보셨나요?
- [x] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [x] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
