### PR TITLE
[SIX-246] 시민은 히어로를 검색 할 수 있다.

### DIFF
--- a/onedayhero-api/src/docs/asciidoc/api/user/profile.adoc
+++ b/onedayhero-api/src/docs/asciidoc/api/user/profile.adoc
@@ -23,3 +23,16 @@ include::{snippets}/profile-hero-find/path-parameters.adoc[]
 
 include::{snippets}/profile-hero-find/http-response.adoc[]
 include::{snippets}/profile-hero-find/response-fields.adoc[]
+
+[[hero-nickname-search]]
+=== 히어로 닉네임 검색
+
+==== HTTP Request
+
+include::{snippets}/hero-nickname-search/http-request.adoc[]
+include::{snippets}/hero-nickname-search/query-parameters.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/hero-nickname-search/http-response.adoc[]
+include::{snippets}/hero-nickname-search/response-fields.adoc[]

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/user/ProfileController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/user/ProfileController.java
@@ -1,18 +1,16 @@
 package com.sixheroes.onedayheroapi.user;
 
-import com.sixheroes.onedayheroapi.global.argumentsresolver.authuser.AuthUser;
 import com.sixheroes.onedayheroapi.global.response.ApiResponse;
 import com.sixheroes.onedayheroapplication.user.ProfileService;
+import com.sixheroes.onedayheroapplication.user.response.HeroSearchResponse;
 import com.sixheroes.onedayheroapplication.user.response.ProfileCitizenResponse;
 import com.sixheroes.onedayheroapplication.user.response.ProfileHeroResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/users")
@@ -37,5 +35,15 @@ public class ProfileController {
         var heroProfile = profileService.findHeroProfile(userId);
 
         return ResponseEntity.ok(ApiResponse.ok(heroProfile));
+    }
+
+    @GetMapping("/hero-search")
+    public ResponseEntity<ApiResponse<Slice<HeroSearchResponse>>> searchHeroes(
+        @RequestParam String nickname,
+        @PageableDefault Pageable pageable
+    ) {
+        var heroSearchResponses = profileService.searchHeroes(nickname, pageable);
+
+        return ResponseEntity.ok(ApiResponse.ok(heroSearchResponses));
     }
 }

--- a/onedayhero-api/src/main/resources/static/docs/index.html
+++ b/onedayhero-api/src/main/resources/static/docs/index.html
@@ -463,6 +463,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <ul class="sectlevel2">
 <li><a href="#profile-citizen-find">시민 프로필 조회</a></li>
 <li><a href="#profile-hero-find">히어로 프로필 조회</a></li>
+<li><a href="#hero-nickname-search">히어로 닉네임 검색</a></li>
 </ul>
 </li>
 <li><a href="#Mission-API">Mission API</a>
@@ -597,7 +598,7 @@ Content-Length: 781
     "heroScore" : 30,
     "isHeroMode" : false
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -777,72 +778,8 @@ Content-Type: image/jpeg
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 33.3333%;">
-<col style="width: 33.3333%;">
-<col style="width: 33.3334%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Path</th>
-<th class="tableblock halign-left valign-top">Type</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>basicInfo</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">유저 기본 정보</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>basicInfo.nickname</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">닉네임</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>basicInfo.gender</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">성별</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>basicInfo.birth</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">태어난 날짜</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>basicInfo.introduce</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">자기 소개</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>favoriteWorkingDay</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">희망 근무 정보</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>favoriteWorkingDay.favoriteDate</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">희망 근무 요일</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>favoriteWorkingDay.favoriteStartTime</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">희망 근무 시작 시간</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>favoriteWorkingDay.favoriteEndTime</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">희망 근무 종료 시간</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>favoriteRegions</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">선호 지역</p></td>
-</tr>
-</tbody>
-</table>
+<div class="paragraph">
+<p>Unresolved directive in api/user/user.adoc - include::/Users/munjong-un/projects/onedayhero/onedayhero-api/build/generated-snippets/user-update/request-fields.adoc[]</p>
 </div>
 <div class="sect3">
 <h4 id="_http_response_2"><a class="link" href="#_http_response_2">HTTP Response</a></h4>
@@ -857,7 +794,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -960,7 +897,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -1143,13 +1080,13 @@ Content-Length: 2193
         "sorted" : false,
         "unsorted" : true
       },
-      "numberOfElements" : 3,
       "first" : true,
       "last" : false,
+      "numberOfElements" : 3,
       "empty" : false
     }
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -1442,7 +1379,7 @@ Content-Length: 1130
       "starScore" : 3,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-22T23:31:21"
+      "createdAt" : "2023-11-21T16:30:23"
     }, {
       "reviewId" : 2,
       "categoryName" : "청소",
@@ -1450,7 +1387,7 @@ Content-Length: 1130
       "starScore" : 4,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-22T23:31:21"
+      "createdAt" : "2023-11-21T16:30:23"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -1471,12 +1408,12 @@ Content-Length: 1130
       "sorted" : false,
       "unsorted" : true
     },
-    "numberOfElements" : 2,
     "first" : true,
     "last" : false,
+    "numberOfElements" : 2,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -1725,7 +1662,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-22T23:31:21"
+      "createdAt" : "2023-11-21T16:30:23"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -1734,7 +1671,7 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-22T23:31:21"
+      "createdAt" : "2023-11-21T16:30:23"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -1755,12 +1692,12 @@ Content-Length: 1142
       "sorted" : false,
       "unsorted" : true
     },
-    "numberOfElements" : 2,
     "first" : true,
     "last" : false,
+    "numberOfElements" : 2,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -1981,7 +1918,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -2067,7 +2004,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -2168,7 +2105,7 @@ Content-Length: 335
     },
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -2321,7 +2258,7 @@ Content-Length: 756
     } ],
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -2453,6 +2390,299 @@ Content-Length: 756
 </table>
 </div>
 </div>
+<div class="sect2">
+<h3 id="hero-nickname-search"><a class="link" href="#hero-nickname-search">히어로 닉네임 검색</a></h3>
+<div class="sect3">
+<h4 id="_http_request_11"><a class="link" href="#_http_request_11">HTTP Request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/users/hero-search?page=0&amp;size=3&amp;nickname=%EB%8B%98 HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Accept: application/json
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>page</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">데이터 크기</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">히어로 이름</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_http_response_11"><a class="link" href="#_http_response_11">HTTP Response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 1432
+
+{
+  "status" : 200,
+  "data" : {
+    "content" : [ {
+      "id" : 2,
+      "nickname" : "달님",
+      "image" : {
+        "originalName" : "profile.jpg",
+        "uniqueName" : "unique.jpg",
+        "path" : "https://"
+      },
+      "favoriteMissionCategories" : [ {
+        "code" : "MC_001",
+        "name" : "서빙"
+      } ],
+      "heroScore" : 30
+    }, {
+      "id" : 3,
+      "nickname" : "별님",
+      "image" : {
+        "originalName" : "profile.jpg",
+        "uniqueName" : "unique.jpg",
+        "path" : "https://"
+      },
+      "favoriteMissionCategories" : [ {
+        "code" : "MC_002",
+        "name" : "주방"
+      } ],
+      "heroScore" : 30
+    }, {
+      "id" : 1,
+      "nickname" : "햇님",
+      "image" : {
+        "originalName" : "profile.jpg",
+        "uniqueName" : "unique.jpg",
+        "path" : "https://"
+      },
+      "favoriteMissionCategories" : [ ],
+      "heroScore" : 30
+    } ],
+    "pageable" : {
+      "pageNumber" : 0,
+      "pageSize" : 3,
+      "sort" : {
+        "empty" : true,
+        "sorted" : false,
+        "unsorted" : true
+      },
+      "offset" : 0,
+      "paged" : true,
+      "unpaged" : false
+    },
+    "size" : 3,
+    "number" : 0,
+    "sort" : {
+      "empty" : true,
+      "sorted" : false,
+      "unsorted" : true
+    },
+    "first" : true,
+    "last" : false,
+    "numberOfElements" : 3,
+    "empty" : false
+  },
+  "serverDateTime" : "2023-11-23T00:32:18"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">히어로 목록 배열</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">히어로 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].nickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">히어로 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].image.originalName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 원본 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].image.uniqueName</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 고유 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].image.path</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 경로</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].favoriteMissionCategories</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선호 미션 카테고리</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].favoriteMissionCategories[].code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선호 미션 카테고리 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].favoriteMissionCategories[].name</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">선호 미션 카테고리 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].heroScore</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">히어로 점수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageable.pageNumber</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageable.pageSize</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 크기</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageable.sort</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 상태 객체</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageable.sort.empty</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 정보가 비어있는지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageable.sort.sorted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 정보가 있는지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageable.sort.unsorted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 정보가 정렬되지 않은지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageable.offset</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageable.paged</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이징이 되어 있는지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.pageable.unpaged</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">페이징이 되어 있지 않은지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.size</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지 조회에서 가져온 리뷰 개수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지 번호</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.sort</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 정보 객체</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.sort.empty</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 정보가 비어있는지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.sort.sorted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 정보가 있는지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.sort.unsorted</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">정렬 정보가 정렬되지 않은지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.numberOfElements</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">현재 페이지의 요소 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.first</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">첫 번째 페이지인지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.last</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막 페이지인지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.empty</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">비어있는지 여부</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
 </div>
 </div>
 <div class="sect1">
@@ -2461,7 +2691,7 @@ Content-Length: 756
 <div class="sect2">
 <h3 id="mission-create"><a class="link" href="#mission-create">시민은 미션을 생성 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_11"><a class="link" href="#_http_request_11">HTTP Request</a></h4>
+<h4 id="_http_request_12"><a class="link" href="#_http_request_12">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/missions HTTP/1.1
@@ -2488,24 +2718,6 @@ Content-Type: image/jpeg
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm--</code></pre>
 </div>
 </div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Auth Credential</p></td>
-</tr>
-</tbody>
-</table>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 33.3333%;">
@@ -2584,7 +2796,7 @@ Content-Type: image/jpeg
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_11"><a class="link" href="#_http_response_11">HTTP Response</a></h4>
+<h4 id="_http_response_12"><a class="link" href="#_http_response_12">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
@@ -2597,7 +2809,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -2642,7 +2854,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-findOne"><a class="link" href="#mission-findOne">유저는 미션을 단 건 조회 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_12"><a class="link" href="#_http_request_12">Http Request</a></h4>
+<h4 id="_http_request_13"><a class="link" href="#_http_request_13">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 4. /api/v1/missions/{missionId}</caption>
 <colgroup>
@@ -2662,24 +2874,6 @@ Content-Length: 95
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Auth Credential</p></td>
-</tr>
-</tbody>
-</table>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/missions/1 HTTP/1.1
@@ -2690,7 +2884,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_12"><a class="link" href="#_http_response_12">Http Response</a></h4>
+<h4 id="_http_response_13"><a class="link" href="#_http_response_13">Http Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2729,7 +2923,7 @@ Content-Length: 755
     "paths" : [ "path://1", "path://2" ],
     "isBookmarked" : true
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -2894,7 +3088,7 @@ Content-Length: 755
 <div class="sect2">
 <h3 id="mission-find-DynamicCondition"><a class="link" href="#mission-find-DynamicCondition">유저는 미션을 필터 조회 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_13"><a class="link" href="#_http_request_13">Http Request</a></h4>
+<h4 id="_http_request_14"><a class="link" href="#_http_request_14">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -2933,24 +3127,6 @@ Content-Length: 755
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Auth Credential</p></td>
-</tr>
-</tbody>
-</table>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/missions?page=0&amp;size=4&amp;sort=&amp;missionCategoryCodes=MC_001&amp;missionCategoryCodes=MC_002&amp;missionDates=2023-10-31&amp;missionDates=2023-11-02&amp;regionIds=1&amp;regionIds=3 HTTP/1.1
@@ -2961,7 +3137,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_13"><a class="link" href="#_http_response_13">Http Response</a></h4>
+<h4 id="_http_response_14"><a class="link" href="#_http_response_14">Http Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3049,12 +3225,12 @@ Content-Length: 2029
       "sorted" : false,
       "unsorted" : true
     },
-    "numberOfElements" : 2,
     "first" : true,
     "last" : true,
+    "numberOfElements" : 2,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -3319,7 +3495,7 @@ Content-Length: 2029
 <div class="sect2">
 <h3 id="mission-progress-find"><a class="link" href="#mission-progress-find">유저는 진행중인 미션을 조회 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_14"><a class="link" href="#_http_request_14">Http Request</a></h4>
+<h4 id="_http_request_15"><a class="link" href="#_http_request_15">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 5. /api/v1/missions/progress/{userId}</caption>
 <colgroup>
@@ -3339,24 +3515,6 @@ Content-Length: 2029
 </tr>
 </tbody>
 </table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Auth Credential</p></td>
-</tr>
-</tbody>
-</table>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/missions/progress?page=0&amp;size=4&amp;sort= HTTP/1.1
@@ -3367,7 +3525,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_14"><a class="link" href="#_http_response_14">Http Response</a></h4>
+<h4 id="_http_response_15"><a class="link" href="#_http_response_15">Http Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3410,12 +3568,12 @@ Content-Length: 874
       "sorted" : false,
       "unsorted" : true
     },
-    "numberOfElements" : 1,
     "first" : true,
     "last" : true,
+    "numberOfElements" : 1,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -3610,44 +3768,10 @@ Content-Length: 874
 <div class="sect2">
 <h3 id="mission-completed-find"><a class="link" href="#mission-completed-find">유저는 완료된 미션을 조회 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_15"><a class="link" href="#_http_request_15">Http Request</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 6. /api/v1/missions/completed/{userId}</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">시민 아이디</p></td>
-</tr>
-</tbody>
-</table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Auth Credential</p></td>
-</tr>
-</tbody>
-</table>
+<h4 id="_http_request_16"><a class="link" href="#_http_request_16">Http Request</a></h4>
+<div class="paragraph">
+<p>Unresolved directive in api/mission/mission.adoc - include::/Users/user/github/Team-6Heroes-OneDayHero-BE/onedayhero-api/build/generated-snippets/mission-completed-find/path-parameters.adoc[]</p>
+</div>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/missions/completed?page=0&amp;size=4&amp;sort= HTTP/1.1
@@ -3658,7 +3782,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_15"><a class="link" href="#_http_response_15">Http Response</a></h4>
+<h4 id="_http_response_16"><a class="link" href="#_http_response_16">Http Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3701,12 +3825,12 @@ Content-Length: 874
       "sorted" : false,
       "unsorted" : true
     },
-    "numberOfElements" : 1,
     "first" : true,
     "last" : true,
+    "numberOfElements" : 1,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -3901,9 +4025,9 @@ Content-Length: 874
 <div class="sect2">
 <h3 id="mission-update"><a class="link" href="#mission-update">시민은 미션을 수정 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_16"><a class="link" href="#_http_request_16">Http Request</a></h4>
+<h4 id="_http_request_17"><a class="link" href="#_http_request_17">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 7. /api/v1/missions/{missionId}</caption>
+<caption class="title">Table 6. /api/v1/missions/{missionId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -3918,24 +4042,6 @@ Content-Length: 874
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
-</tr>
-</tbody>
-</table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Auth Credential</p></td>
 </tr>
 </tbody>
 </table>
@@ -4037,7 +4143,7 @@ Content-Type: image/jpeg
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_16"><a class="link" href="#_http_response_16">HTTP Response</a></h4>
+<h4 id="_http_response_17"><a class="link" href="#_http_response_17">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4049,7 +4155,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -4094,7 +4200,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-extend"><a class="link" href="#mission-extend">시민은 미션을 연장 할 수 있다.</a></h3>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 8. /api/v1/missions/{missionId}/extend</caption>
+<caption class="title">Table 7. /api/v1/missions/{missionId}/extend</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4109,24 +4215,6 @@ Content-Length: 95
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
-</tr>
-</tbody>
-</table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Auth Credential</p></td>
 </tr>
 </tbody>
 </table>
@@ -4183,7 +4271,7 @@ Host: localhost:8080
 </tbody>
 </table>
 <div class="sect3">
-<h4 id="_http_response_17"><a class="link" href="#_http_response_17">HTTP Response</a></h4>
+<h4 id="_http_response_18"><a class="link" href="#_http_response_18">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4195,7 +4283,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -4240,7 +4328,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-complete"><a class="link" href="#mission-complete">시민은 미션을 완료 상태로 변경 할 수 있다.</a></h3>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 9. /api/v1/missions/{missionId}/complete</caption>
+<caption class="title">Table 8. /api/v1/missions/{missionId}/complete</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4255,24 +4343,6 @@ Content-Length: 95
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
-</tr>
-</tbody>
-</table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Auth Credential</p></td>
 </tr>
 </tbody>
 </table>
@@ -4306,7 +4376,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <div class="sect3">
-<h4 id="_http_response_18"><a class="link" href="#_http_response_18">HTTP Response</a></h4>
+<h4 id="_http_response_19"><a class="link" href="#_http_response_19">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4318,7 +4388,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:21"
 }</code></pre>
 </div>
 </div>
@@ -4363,9 +4433,9 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-delete"><a class="link" href="#mission-delete">시민은 미션을 삭제 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_17"><a class="link" href="#_http_request_17">Http Request</a></h4>
+<h4 id="_http_request_18"><a class="link" href="#_http_request_18">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 10. /api/v1/missions/{missionId}</caption>
+<caption class="title">Table 9. /api/v1/missions/{missionId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -4380,24 +4450,6 @@ Content-Length: 95
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionId</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
-</tr>
-</tbody>
-</table>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Auth Credential</p></td>
 </tr>
 </tbody>
 </table>
@@ -4432,7 +4484,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_19"><a class="link" href="#_http_response_19">HTTP Response</a></h4>
+<h4 id="_http_response_20"><a class="link" href="#_http_response_20">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
@@ -4442,7 +4494,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -4487,7 +4539,7 @@ Content-Length: 81
 <div class="sect2">
 <h3 id="mission-bookmark-create"><a class="link" href="#mission-bookmark-create">미션 찜 등록</a></h3>
 <div class="sect3">
-<h4 id="_http_request_18"><a class="link" href="#_http_request_18">HTTP Request</a></h4>
+<h4 id="_http_request_19"><a class="link" href="#_http_request_19">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/bookmarks HTTP/1.1
@@ -4542,7 +4594,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_20"><a class="link" href="#_http_response_20">HTTP Response</a></h4>
+<h4 id="_http_response_21"><a class="link" href="#_http_response_21">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4554,7 +4606,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:19"
+  "serverDateTime" : "2023-11-21T16:30:21"
 }</code></pre>
 </div>
 </div>
@@ -4599,7 +4651,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-bookmark-cancel"><a class="link" href="#mission-bookmark-cancel">미션 찜 취소</a></h3>
 <div class="sect3">
-<h4 id="_http_request_19"><a class="link" href="#_http_request_19">HTTP Request</a></h4>
+<h4 id="_http_request_20"><a class="link" href="#_http_request_20">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/bookmarks HTTP/1.1
@@ -4654,7 +4706,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_21"><a class="link" href="#_http_response_21">HTTP Response</a></h4>
+<h4 id="_http_response_22"><a class="link" href="#_http_response_22">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
@@ -4664,7 +4716,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:21"
 }</code></pre>
 </div>
 </div>
@@ -4724,7 +4776,7 @@ Content-Length: 81
 <div class="sect2">
 <h3 id="mission-match-create"><a class="link" href="#mission-match-create">미션 매치 생성</a></h3>
 <div class="sect3">
-<h4 id="_http_request_20"><a class="link" href="#_http_request_20">HTTP Request</a></h4>
+<h4 id="_http_request_21"><a class="link" href="#_http_request_21">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/mission-matches HTTP/1.1
@@ -4785,7 +4837,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_22"><a class="link" href="#_http_response_22">HTTP Response</a></h4>
+<h4 id="_http_response_23"><a class="link" href="#_http_response_23">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4797,7 +4849,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -4842,7 +4894,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-match-cancel"><a class="link" href="#mission-match-cancel">미션 매치 취소</a></h3>
 <div class="sect3">
-<h4 id="_http_request_21"><a class="link" href="#_http_request_21">HTTP Request</a></h4>
+<h4 id="_http_request_22"><a class="link" href="#_http_request_22">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/mission-matches/cancel HTTP/1.1
@@ -4897,7 +4949,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_23"><a class="link" href="#_http_response_23">HTTP Response</a></h4>
+<h4 id="_http_response_24"><a class="link" href="#_http_response_24">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4909,7 +4961,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -4959,7 +5011,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-proposal-create"><a class="link" href="#mission-proposal-create">미션 제안 생성</a></h3>
 <div class="sect3">
-<h4 id="_http_request_22"><a class="link" href="#_http_request_22">HTTP Request</a></h4>
+<h4 id="_http_request_23"><a class="link" href="#_http_request_23">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/mission-proposals HTTP/1.1
@@ -5020,7 +5072,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_24"><a class="link" href="#_http_response_24">HTTP Response</a></h4>
+<h4 id="_http_response_25"><a class="link" href="#_http_response_25">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
@@ -5033,7 +5085,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -5078,7 +5130,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-proposal-approve"><a class="link" href="#mission-proposal-approve">미션 제안 승낙</a></h3>
 <div class="sect3">
-<h4 id="_http_request_23"><a class="link" href="#_http_request_23">HTTP Request</a></h4>
+<h4 id="_http_request_24"><a class="link" href="#_http_request_24">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/mission-proposals/1/approve HTTP/1.1
@@ -5105,7 +5157,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 11. /api/v1/mission-proposals/{missionProposalId}/approve</caption>
+<caption class="title">Table 10. /api/v1/mission-proposals/{missionProposalId}/approve</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -5125,7 +5177,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_25"><a class="link" href="#_http_response_25">HTTP Response</a></h4>
+<h4 id="_http_response_26"><a class="link" href="#_http_response_26">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -5137,7 +5189,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -5182,7 +5234,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-proposal-reject"><a class="link" href="#mission-proposal-reject">미션 제안 거절</a></h3>
 <div class="sect3">
-<h4 id="_http_request_24"><a class="link" href="#_http_request_24">HTTP Request</a></h4>
+<h4 id="_http_request_25"><a class="link" href="#_http_request_25">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/mission-proposals/1/reject HTTP/1.1
@@ -5210,7 +5262,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_26"><a class="link" href="#_http_response_26">HTTP Response</a></h4>
+<h4 id="_http_response_27"><a class="link" href="#_http_response_27">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -5222,7 +5274,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -5267,7 +5319,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-proposal-find"><a class="link" href="#mission-proposal-find">제안받은 미션 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_25"><a class="link" href="#_http_request_25">HTTP Request</a></h4>
+<h4 id="_http_request_26"><a class="link" href="#_http_request_26">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/mission-proposals?heroId=1&amp;page=0&amp;size=5 HTTP/1.1
@@ -5322,7 +5374,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_27"><a class="link" href="#_http_response_27">HTTP Response</a></h4>
+<h4 id="_http_response_28"><a class="link" href="#_http_response_28">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -5338,7 +5390,7 @@ Content-Length: 3574
         "id" : 1,
         "status" : "MATCHING",
         "bookmarkCount" : 5,
-        "createdAt" : "2023-11-22T23:31:20",
+        "createdAt" : "2023-11-21T16:30:22",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -5362,7 +5414,7 @@ Content-Length: 3574
         "id" : 2,
         "status" : "MATCHING",
         "bookmarkCount" : 5,
-        "createdAt" : "2023-11-21T23:31:20",
+        "createdAt" : "2023-11-20T16:30:22",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -5386,7 +5438,7 @@ Content-Length: 3574
         "id" : 3,
         "status" : "MATCHING_COMPLETED",
         "bookmarkCount" : 5,
-        "createdAt" : "2023-11-19T23:31:20",
+        "createdAt" : "2023-11-18T16:30:22",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -5410,7 +5462,7 @@ Content-Length: 3574
         "id" : 4,
         "status" : "MISSION_COMPLETED",
         "bookmarkCount" : 5,
-        "createdAt" : "2023-11-20T23:31:20",
+        "createdAt" : "2023-11-19T16:30:22",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -5434,7 +5486,7 @@ Content-Length: 3574
         "id" : 5,
         "status" : "EXPIRED",
         "bookmarkCount" : 5,
-        "createdAt" : "2023-11-19T23:31:20",
+        "createdAt" : "2023-11-18T16:30:22",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -5472,12 +5524,12 @@ Content-Length: 3574
       "sorted" : false,
       "unsorted" : true
     },
-    "numberOfElements" : 5,
     "first" : true,
     "last" : false,
+    "numberOfElements" : 5,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-22T23:31:20"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -5717,7 +5769,7 @@ Content-Length: 3574
 <div class="sect2">
 <h3 id="review-create"><a class="link" href="#review-create">리뷰 생성</a></h3>
 <div class="sect3">
-<h4 id="_http_request_26"><a class="link" href="#_http_request_26">HTTP Request</a></h4>
+<h4 id="_http_request_27"><a class="link" href="#_http_request_27">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviews HTTP/1.1
@@ -5797,7 +5849,7 @@ Content-Type: image/jpeg
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_28"><a class="link" href="#_http_response_28">HTTP Response</a></h4>
+<h4 id="_http_response_29"><a class="link" href="#_http_response_29">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
@@ -5810,7 +5862,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -5855,7 +5907,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="review-update"><a class="link" href="#review-update">리뷰 수정</a></h3>
 <div class="sect3">
-<h4 id="_http_request_27"><a class="link" href="#_http_request_27">HTTP Request</a></h4>
+<h4 id="_http_request_28"><a class="link" href="#_http_request_28">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviews/1 HTTP/1.1
@@ -5905,7 +5957,7 @@ Content-Type: image/jpeg
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_29"><a class="link" href="#_http_response_29">HTTP Response</a></h4>
+<h4 id="_http_response_30"><a class="link" href="#_http_response_30">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -5917,7 +5969,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -5962,7 +6014,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="_리뷰_상세_조회"><a class="link" href="#_리뷰_상세_조회">리뷰 상세 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_28"><a class="link" href="#_http_request_28">HTTP Request</a></h4>
+<h4 id="_http_request_29"><a class="link" href="#_http_request_29">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/1 HTTP/1.1
@@ -5972,7 +6024,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 12. /api/v1/reviews/{reviewId}</caption>
+<caption class="title">Table 11. /api/v1/reviews/{reviewId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -5992,7 +6044,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_30"><a class="link" href="#_http_response_30">HTTP Response</a></h4>
+<h4 id="_http_response_31"><a class="link" href="#_http_response_31">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -6023,9 +6075,9 @@ Content-Length: 719
       "uniqueName" : "B",
       "path" : "S3 이미지 주소B"
     } ],
-    "createdAt" : "2023-11-22T23:31:21"
+    "createdAt" : "2023-11-21T16:30:22"
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -6145,7 +6197,7 @@ Content-Length: 719
 <div class="sect2">
 <h3 id="_리뷰_삭제"><a class="link" href="#_리뷰_삭제">리뷰 삭제</a></h3>
 <div class="sect3">
-<h4 id="_http_request_29"><a class="link" href="#_http_request_29">HTTP Request</a></h4>
+<h4 id="_http_request_30"><a class="link" href="#_http_request_30">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviews/1 HTTP/1.1
@@ -6154,7 +6206,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 13. /api/v1/reviews/{reviewId}</caption>
+<caption class="title">Table 12. /api/v1/reviews/{reviewId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -6174,7 +6226,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_31"><a class="link" href="#_http_response_31">HTTP Response</a></h4>
+<h4 id="_http_response_32"><a class="link" href="#_http_response_32">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
@@ -6184,7 +6236,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:23"
 }</code></pre>
 </div>
 </div>
@@ -6193,7 +6245,7 @@ Content-Length: 81
 <div class="sect2">
 <h3 id="specific-user-received-reviews"><a class="link" href="#specific-user-received-reviews">특정 유저가 받은 리뷰 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_30"><a class="link" href="#_http_request_30">HTTP Request</a></h4>
+<h4 id="_http_request_31"><a class="link" href="#_http_request_31">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/users/1/receive?page=0&amp;size=5&amp;sort= HTTP/1.1
@@ -6204,7 +6256,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 14. /api/v1/reviews/users/{userId}/receive</caption>
+<caption class="title">Table 13. /api/v1/reviews/users/{userId}/receive</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -6250,7 +6302,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_32"><a class="link" href="#_http_response_32">HTTP Response</a></h4>
+<h4 id="_http_response_33"><a class="link" href="#_http_response_33">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -6268,7 +6320,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-22T23:31:21"
+      "createdAt" : "2023-11-21T16:30:22"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -6277,7 +6329,7 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-22T23:31:21"
+      "createdAt" : "2023-11-21T16:30:22"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -6298,12 +6350,12 @@ Content-Length: 1142
       "sorted" : false,
       "unsorted" : true
     },
-    "numberOfElements" : 2,
     "first" : true,
     "last" : false,
+    "numberOfElements" : 2,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-22T23:31:21"
+  "serverDateTime" : "2023-11-21T16:30:22"
 }</code></pre>
 </div>
 </div>
@@ -6878,7 +6930,7 @@ Content-Length: 81
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-11-22 23:30:44 +0900
+Last updated 2023-11-13 15:40:59 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/user/UserControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/user/UserControllerTest.java
@@ -34,7 +34,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.List;
-import java.util.Map;
 
 import static com.sixheroes.onedayheroapi.docs.DocumentFormatGenerator.*;
 import static com.sixheroes.onedayherocommon.converter.DateTimeConverter.convertDateToString;
@@ -49,8 +48,6 @@ import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuild
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
 import static org.springframework.restdocs.request.RequestDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
-import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -134,9 +131,18 @@ class UserControllerTest extends RestDocsSupport {
                         .optional()
                         .description("자기 소개"),
                     fieldWithPath("data.image").type(JsonFieldType.OBJECT).description("프로필 이미지"),
-                    fieldWithPath("data.image.originalName").type(JsonFieldType.STRING).description("원본 이름"),
-                    fieldWithPath("data.image.uniqueName").type(JsonFieldType.STRING).description("고유 이름"),
-                    fieldWithPath("data.image.path").type(JsonFieldType.STRING).description("이미지 경로"),
+                    fieldWithPath("data.image.originalName")
+                        .type(JsonFieldType.STRING)
+                        .optional()
+                        .description("원본 이름"),
+                    fieldWithPath("data.image.uniqueName")
+                        .type(JsonFieldType.STRING)
+                        .optional()
+                        .description("고유 이름"),
+                    fieldWithPath("data.image.path")
+                        .type(JsonFieldType.STRING)
+                        .optional()
+                        .description("이미지 경로"),
                     fieldWithPath("data.favoriteWorkingDay").type(JsonFieldType.OBJECT).description("희망 근무 정보"),
                     fieldWithPath("data.favoriteWorkingDay.favoriteDate")
                         .optional()

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/MissionCategoryReader.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/MissionCategoryReader.java
@@ -3,11 +3,16 @@ package com.sixheroes.onedayheroapplication.mission;
 import com.sixheroes.onedayherocommon.error.ErrorCode;
 import com.sixheroes.onedayherodomain.mission.MissionCategory;
 import com.sixheroes.onedayherodomain.mission.repository.MissionCategoryRepository;
+import com.sixheroes.onedayherodomain.mission.repository.dto.MissionCategoryDto;
+import com.sixheroes.onedayherodomain.user.User;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -22,5 +27,14 @@ public class MissionCategoryReader {
                     log.warn("존재하지 않는 미션 카테고리가 입력되었습니다. id : {}", missionCategoryId);
                     return new NoSuchElementException(ErrorCode.EMC_001.name());
                 });
+    }
+
+    public Map<Long, List<MissionCategoryDto>> findAllByUser(
+        List<User> user
+    ) {
+        var missionCategories = missionCategoryRepository.findMissionCategoriesByUser(user);
+
+        return missionCategories.stream()
+            .collect(Collectors.groupingBy(MissionCategoryDto::userId));
     }
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCategoryResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/mission/response/MissionCategoryResponse.java
@@ -12,7 +12,6 @@ public record MissionCategoryResponse(
         String code,
         String name
 ) {
-
     public static MissionCategoryResponse from(
             MissionQueryResponse response
     ) {

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/ProfileService.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/ProfileService.java
@@ -1,9 +1,13 @@
 package com.sixheroes.onedayheroapplication.user;
 
+import com.sixheroes.onedayheroapplication.mission.MissionCategoryReader;
 import com.sixheroes.onedayheroapplication.region.RegionReader;
+import com.sixheroes.onedayheroapplication.user.response.HeroSearchResponse;
 import com.sixheroes.onedayheroapplication.user.response.ProfileCitizenResponse;
 import com.sixheroes.onedayheroapplication.user.response.ProfileHeroResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -14,6 +18,7 @@ public class ProfileService {
 
     private final UserReader userReader;
     private final RegionReader regionReader;
+    private final MissionCategoryReader missionCategoryReader;
 
     public ProfileCitizenResponse findCitizenProfile(
         Long userId
@@ -32,5 +37,16 @@ public class ProfileService {
         var regions = regionReader.findByUser(user);
 
         return ProfileHeroResponse.from(user, regions);
+    }
+
+    public Slice<HeroSearchResponse> searchHeroes(
+        String nickname,
+        Pageable pageable
+    ) {
+        var heroes = userReader.findHeroes(nickname, pageable);
+
+        var missionCategories = missionCategoryReader.findAllByUser(heroes.getContent());
+
+        return heroes.map(u -> HeroSearchResponse.of(u, missionCategories.get(u.getId())));
     }
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/UserReader.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/UserReader.java
@@ -5,6 +5,8 @@ import com.sixheroes.onedayherodomain.user.User;
 import com.sixheroes.onedayherodomain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +18,8 @@ import java.util.NoSuchElementException;
 @Component
 public class UserReader {
 
+    private static final String SEARCH = "%%%s%%";
+
     private final UserRepository userRepository;
 
     public User findOne(
@@ -26,5 +30,12 @@ public class UserReader {
                     log.debug("존재하지 않는 유저 아이디입니다. id : {}", userId);
                     return new NoSuchElementException(ErrorCode.EUC_000.name());
                 });
+    }
+
+    public Slice<User> findHeroes(
+        String nickname,
+        Pageable pageable
+    ) {
+        return userRepository.findByNicknameAndIsHeroMode(SEARCH.formatted(nickname), pageable);
     }
 }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/response/HeroSearchResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/response/HeroSearchResponse.java
@@ -1,0 +1,65 @@
+package com.sixheroes.onedayheroapplication.user.response;
+
+import com.sixheroes.onedayherodomain.mission.repository.dto.MissionCategoryDto;
+import com.sixheroes.onedayherodomain.user.User;
+import com.sixheroes.onedayherodomain.user.UserBasicInfo;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Slf4j
+@Builder
+public record HeroSearchResponse(
+    Long id,
+    String nickname,
+    UserImageResponse image,
+    List<MissionCategoryResponse> favoriteMissionCategories,
+    Integer heroScore
+){
+
+    public static HeroSearchResponse of(
+        User user,
+        List<MissionCategoryDto> missionCategories
+    ) {
+        var missionCategoryResponses = Optional.ofNullable(missionCategories)
+            .orElseGet(ArrayList::new)
+            .stream()
+            .map(MissionCategoryResponse::from)
+            .toList();
+
+        var userImageResponse = user.getUserImages().stream()
+            .map(UserImageResponse::from)
+            .findFirst()
+            .orElseGet(UserImageResponse::empty);
+
+        var nickname = Optional.of(user.getUserBasicInfo())
+            .map(UserBasicInfo::getNickname)
+            .orElse(null);
+
+        return HeroSearchResponse.builder()
+            .id(user.getId())
+            .nickname(nickname)
+            .image(userImageResponse)
+            .heroScore(user.getHeroScore())
+            .favoriteMissionCategories(missionCategoryResponses)
+            .build();
+    }
+
+    public record MissionCategoryResponse(
+        String code,
+        String name
+    ) {
+
+        static MissionCategoryResponse from(
+            MissionCategoryDto missionCategoryDto
+        ) {
+            return new MissionCategoryResponse(
+                missionCategoryDto.missionCategoryCode().name(),
+                missionCategoryDto.name()
+            );
+        }
+    }
+}

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/IntegrationApplicationTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/IntegrationApplicationTest.java
@@ -22,6 +22,7 @@ import com.sixheroes.onedayherodomain.region.Region;
 import com.sixheroes.onedayherodomain.region.repository.RegionRepository;
 import com.sixheroes.onedayherodomain.review.repository.ReviewRepository;
 import com.sixheroes.onedayherodomain.user.repository.UserImageRepository;
+import com.sixheroes.onedayherodomain.user.repository.UserMissionCategoryRepository;
 import com.sixheroes.onedayherodomain.user.repository.UserRegionRepository;
 import com.sixheroes.onedayherodomain.user.repository.UserRepository;
 import org.junit.jupiter.api.BeforeAll;
@@ -84,6 +85,9 @@ public abstract class IntegrationApplicationTest {
 
     @Autowired
     protected UserRegionRepository userRegionRepository;
+
+    @Autowired
+    protected UserMissionCategoryRepository userMissionCategoryRepository;
 
     @Autowired
     protected UserService userService;

--- a/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/user/UserServiceTest.java
+++ b/onedayhero-application/src/test/java/com/sixheroes/onedayheroapplication/user/UserServiceTest.java
@@ -8,17 +8,12 @@ import com.sixheroes.onedayheroapplication.user.request.UserBasicInfoServiceRequ
 import com.sixheroes.onedayheroapplication.user.request.UserFavoriteWorkingDayServiceRequest;
 import com.sixheroes.onedayheroapplication.user.request.UserServiceUpdateRequest;
 import com.sixheroes.onedayherocommon.error.ErrorCode;
-import com.sixheroes.onedayherodomain.region.Region;
-import com.sixheroes.onedayherodomain.region.repository.RegionRepository;
 import com.sixheroes.onedayherodomain.global.DefaultNicknameGenerator;
+import com.sixheroes.onedayherodomain.region.Region;
 import com.sixheroes.onedayherodomain.user.*;
-import com.sixheroes.onedayherodomain.user.repository.UserImageRepository;
-import com.sixheroes.onedayherodomain.user.repository.UserRegionRepository;
-import com.sixheroes.onedayherodomain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.io.IOException;
@@ -30,29 +25,14 @@ import java.util.NoSuchElementException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.assertj.core.api.SoftAssertions.assertSoftly;
 
 @Transactional
 class UserServiceTest extends IntegrationApplicationTest {
-
-    @Autowired
-    private UserRepository userRepository;
-
-    @Autowired
-    private UserImageRepository userImageRepository;
-
-    @Autowired
-    private UserRegionRepository userRegionRepository;
-
-    @Autowired
-    private RegionRepository regionRepository;
-
-    @Autowired
-    private UserService userService;
 
     @DisplayName("처음 OAUTH 로그인을 시도하면 기본 설정값으로 유저가 저장된다.")
     @Test

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/MissionCategoryRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/MissionCategoryRepository.java
@@ -1,7 +1,23 @@
 package com.sixheroes.onedayherodomain.mission.repository;
 
 import com.sixheroes.onedayherodomain.mission.MissionCategory;
+import com.sixheroes.onedayherodomain.mission.repository.dto.MissionCategoryDto;
+import com.sixheroes.onedayherodomain.user.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 public interface MissionCategoryRepository extends JpaRepository<MissionCategory, Long> {
+
+    @Query("""
+        select new com.sixheroes.onedayherodomain.mission.repository.dto.MissionCategoryDto(
+            umc.user.id, mc.missionCategoryCode, mc.name
+        )
+        from MissionCategory mc
+        join UserMissionCategory umc on mc.id = umc.missionCategoryId
+        where umc.user in :users
+    """)
+    List<MissionCategoryDto> findMissionCategoriesByUser(@Param("users") List<User> users);
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/dto/MissionCategoryDto.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/mission/repository/dto/MissionCategoryDto.java
@@ -1,0 +1,10 @@
+package com.sixheroes.onedayherodomain.mission.repository.dto;
+
+import com.sixheroes.onedayherodomain.mission.MissionCategoryCode;
+
+public record MissionCategoryDto(
+    Long userId,
+    MissionCategoryCode missionCategoryCode,
+    String name
+) {
+}

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserMissionCategory.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/UserMissionCategory.java
@@ -29,15 +29,15 @@ public class UserMissionCategory extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(name = "mission_id", nullable = false)
-    private Long missionId;
+    @Column(name = "mission_category_id", nullable = false)
+    private Long missionCategoryId;
 
     @Builder
     private UserMissionCategory(
         User user,
-        Long missionId
+        Long missionCategoryId
     ) {
         this.user = user;
-        this.missionId = missionId;
+        this.missionCategoryId = missionCategoryId;
     }
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/repository/UserRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/user/repository/UserRepository.java
@@ -1,11 +1,26 @@
 package com.sixheroes.onedayherodomain.user.repository;
 
 import com.sixheroes.onedayherodomain.user.User;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail_Email(String email_email);
+
+    @Query("""
+        select u
+        from User u
+        where u.userBasicInfo.nickname like :nickname and u.isHeroMode = true
+        order by u.userBasicInfo.nickname
+    """)
+    Slice<User> findByNicknameAndIsHeroMode(
+        @Param("nickname") String nickname,
+        Pageable pageable
+    );
 }


### PR DESCRIPTION
## 🖊️ 1. Changes

- 닉네임을 통해 히어로를 검색 API를 구현 및 RestDocs를 작성했습니다.
- 닉네임을 통한 히어로 검색 서비스 로직을 구현했습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 검색된 히어로마다 Repository에서 선호 미션 카테고리를 가져와야 합니다. 이때 N + 1문제가 발생하므로 In으로 한 번에 가져오도록 했습니다. 가져온 뒤 stream을 사용하여 userId로 그루핑한 뒤 응답값을 만들었습니다.
2. 양방향은 설계가 복잡해질 뿐만 아니라 매번 선호 미션 카테고리가 조회 및 수정되는 상황이 아니라 매핑하지 않았습니다.

## 😌 4. To Reviewer

-

## 🙌 6. Checklist
- [x] - 통합 테스트를 수행해보셨나요?
- [x] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [x] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
