### PR TITLE
[SIX-197] 현재 참여중인 채팅방을 조회하는 로직 구현

### DIFF
--- a/onedayhero-api/src/docs/asciidoc/api/chatroom/chatroom.adoc
+++ b/onedayhero-api/src/docs/asciidoc/api/chatroom/chatroom.adoc
@@ -16,7 +16,8 @@ include::{snippets}/chatRoom-create/response-fields.adoc[]
 
 ==== HTTP Request
 
-include::{snippets}/chatRoom-joined/path-parameters.adoc[]
+include::{snippets}/chatRoom-joined/http-request.adoc[]
+include::{snippets}/chatRoom-joined/request-headers.adoc[]
 
 ==== HTTP Response
 

--- a/onedayhero-api/src/docs/asciidoc/index.adoc
+++ b/onedayhero-api/src/docs/asciidoc/index.adoc
@@ -63,3 +63,8 @@ include::api/sse/sse.adoc[]
 == Alarm API
 
 include::api/alarm/alarm.adoc[]
+
+[[Chatroom-API]]
+== Chatroom API
+
+include::api/chatroom/chatroom.adoc[]

--- a/onedayhero-api/src/main/resources/static/docs/index.html
+++ b/onedayhero-api/src/main/resources/static/docs/index.html
@@ -447,6 +447,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div id="toc" class="toc2">
 <div id="toctitle">Table of Contents</div>
 <ul class="sectlevel1">
+<li><a href="#Login-API">Kakao Login API</a>
+<ul class="sectlevel2">
+<li><a href="#kakao-signUp">카카오 회원가입 후 로그인</a></li>
+<li><a href="#kakao-login">카카오 로그인</a></li>
+</ul>
+</li>
 <li><a href="#User-API">User API</a>
 <ul class="sectlevel2">
 <li><a href="#user-find">유저 정보 조회</a></li>
@@ -525,17 +531,282 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#alarm-delete">알림 삭제</a></li>
 </ul>
 </li>
+<li><a href="#Chatroom-API">Chatroom API</a>
+<ul class="sectlevel2">
+<li><a href="#chatroom-create">시민은 채팅방을 만들 수 있다.</a></li>
+<li><a href="#chatRoom-joined">유저는 현재 자신이 들어가 있는 채팅방을 조회 할 수 있다.</a></li>
+<li><a href="#chatRoom-exit">유저는 현재 자신이 들어가 있는 채팅방을 나갈 수 있다.</a></li>
+</ul>
+</li>
 </ul>
 </div>
 </div>
 <div id="content">
+<div class="sect1">
+<h2 id="Login-API"><a class="link" href="#Login-API">Kakao Login API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="kakao-signUp"><a class="link" href="#kakao-signUp">카카오 회원가입 후 로그인</a></h3>
+<div class="sect3">
+<h4 id="_http_request"><a class="link" href="#_http_request">HTTP Request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/kakao/login HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 35
+Host: localhost:8080
+
+{
+  "code" : "authorization code"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_fields"><a class="link" href="#_request_fields">Request Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인가 코드</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_http_response"><a class="link" href="#_http_response">HTTP Response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Set-Cookie: refreshToken=974ceba1-ab67-44b9-9d26-2cdba289889d; HttpOnly
+Location:
+Content-Type: application/json;charset=UTF-8
+Content-Length: 134
+
+{
+  "status" : 201,
+  "data" : {
+    "userId" : 1,
+    "accessToken" : "accessToken"
+  },
+  "serverDateTime" : "2023-11-24T13:30:48"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields"><a class="link" href="#_response_fields">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">회원가입 후 로그인한 유저 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.accessToken</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">발급된 액세스 토큰</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="kakao-login"><a class="link" href="#kakao-login">카카오 로그인</a></h3>
+<div class="sect3">
+<h4 id="_http_request_2"><a class="link" href="#_http_request_2">HTTP Request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/auth/kakao/login HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 35
+Host: localhost:8080
+
+{
+  "code" : "authorization code"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_fields_2"><a class="link" href="#_request_fields_2">Request Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">인가 코드</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_http_response_2"><a class="link" href="#_http_response_2">HTTP Response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Set-Cookie: refreshToken=082c76cc-1672-44fb-aac2-670773544f91; HttpOnly
+Content-Type: application/json;charset=UTF-8
+Content-Length: 134
+
+{
+  "status" : 200,
+  "data" : {
+    "userId" : 1,
+    "accessToken" : "accessToken"
+  },
+  "serverDateTime" : "2023-11-24T13:30:48"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_2"><a class="link" href="#_response_fields_2">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">로그인 유저 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.accessToken</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">발급된 액세스 토큰</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
 <div class="sect1">
 <h2 id="User-API"><a class="link" href="#User-API">User API</a></h2>
 <div class="sectionbody">
 <div class="sect2">
 <h3 id="user-find"><a class="link" href="#user-find">유저 정보 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request"><a class="link" href="#_http_request">HTTP Request</a></h4>
+<h4 id="_http_request_3"><a class="link" href="#_http_request_3">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/me HTTP/1.1
@@ -564,7 +835,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response"><a class="link" href="#_http_response">HTTP Response</a></h4>
+<h4 id="_http_response_3"><a class="link" href="#_http_response_3">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -604,13 +875,13 @@ Content-Length: 781
     "heroScore" : 30,
     "isHeroMode" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:42"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields"><a class="link" href="#_response_fields">Response Fields</a></h4>
+<h4 id="_response_fields_3"><a class="link" href="#_response_fields_3">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -797,7 +1068,7 @@ Content-Length: 781
 <div class="sect2">
 <h3 id="user-update"><a class="link" href="#user-update">유저 정보 수정</a></h3>
 <div class="sect3">
-<h4 id="_http_request_2"><a class="link" href="#_http_request_2">HTTP Request</a></h4>
+<h4 id="_http_request_4"><a class="link" href="#_http_request_4">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/me HTTP/1.1
@@ -905,7 +1176,7 @@ Content-Type: image/jpeg
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_2"><a class="link" href="#_http_response_2">HTTP Response</a></h4>
+<h4 id="_http_response_4"><a class="link" href="#_http_response_4">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -917,13 +1188,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:42"
+  "serverDateTime" : "2023-11-24T13:30:51"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_2"><a class="link" href="#_response_fields_2">Response Fields</a></h4>
+<h4 id="_response_fields_4"><a class="link" href="#_response_fields_4">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -977,7 +1248,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="user-image-delete"><a class="link" href="#user-image-delete">유저 이미지 삭제</a></h3>
 <div class="sect3">
-<h4 id="_http_request_3"><a class="link" href="#_http_request_3">HTTP Request</a></h4>
+<h4 id="_http_request_5"><a class="link" href="#_http_request_5">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/me/user-images/1 HTTP/1.1
@@ -1025,7 +1296,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_3"><a class="link" href="#_http_response_3">HTTP Response</a></h4>
+<h4 id="_http_response_5"><a class="link" href="#_http_response_5">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
@@ -1035,13 +1306,13 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T01:30:42"
+  "serverDateTime" : "2023-11-24T13:30:51"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_3"><a class="link" href="#_response_fields_3">Response Fields</a></h4>
+<h4 id="_response_fields_5"><a class="link" href="#_response_fields_5">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -1088,7 +1359,7 @@ Content-Length: 81
 <div class="sect2">
 <h3 id="mission-bookmark-cancel"><a class="link" href="#mission-bookmark-cancel">내 미션 찜 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_4"><a class="link" href="#_http_request_4">HTTP Request</a></h4>
+<h4 id="_http_request_6"><a class="link" href="#_http_request_6">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/me/bookmarks?page=0&amp;size=3&amp;sort= HTTP/1.1
@@ -1142,7 +1413,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_4"><a class="link" href="#_http_response_4">HTTP Response</a></h4>
+<h4 id="_http_response_6"><a class="link" href="#_http_response_6">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1237,13 +1508,13 @@ Content-Length: 2193
       "empty" : false
     }
   },
-  "serverDateTime" : "2023-11-24T01:30:42"
+  "serverDateTime" : "2023-11-24T13:30:51"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_4"><a class="link" href="#_response_fields_4">Response Fields</a></h4>
+<h4 id="_response_fields_6"><a class="link" href="#_response_fields_6">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -1542,7 +1813,7 @@ Content-Length: 2193
 <div class="sect2">
 <h3 id="user-sent-reviews"><a class="link" href="#user-sent-reviews">내가 작성한 리뷰 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_5"><a class="link" href="#_http_request_5">HTTP Request</a></h4>
+<h4 id="_http_request_7"><a class="link" href="#_http_request_7">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/me/reviews/send?page=0&amp;size=5&amp;sort= HTTP/1.1
@@ -1598,7 +1869,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_5"><a class="link" href="#_http_response_5">HTTP Response</a></h4>
+<h4 id="_http_response_7"><a class="link" href="#_http_response_7">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1615,7 +1886,7 @@ Content-Length: 1130
       "starScore" : 3,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-24T01:30:42"
+      "createdAt" : "2023-11-24T13:30:50"
     }, {
       "reviewId" : 2,
       "categoryName" : "청소",
@@ -1623,7 +1894,7 @@ Content-Length: 1130
       "starScore" : 4,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-24T01:30:42"
+      "createdAt" : "2023-11-24T13:30:50"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -1649,13 +1920,13 @@ Content-Length: 1130
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:42"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_5"><a class="link" href="#_response_fields_5">Response Fields</a></h4>
+<h4 id="_response_fields_7"><a class="link" href="#_response_fields_7">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -1891,7 +2162,7 @@ Content-Length: 1130
 <div class="sect2">
 <h3 id="user-received-reviews"><a class="link" href="#user-received-reviews">내가 받은 리뷰 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_6"><a class="link" href="#_http_request_6">HTTP Request</a></h4>
+<h4 id="_http_request_8"><a class="link" href="#_http_request_8">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/me/reviews/receive?page=0&amp;size=5&amp;sort= HTTP/1.1
@@ -1947,7 +2218,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_6"><a class="link" href="#_http_response_6">HTTP Response</a></h4>
+<h4 id="_http_response_8"><a class="link" href="#_http_response_8">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -1965,7 +2236,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-24T01:30:42"
+      "createdAt" : "2023-11-24T13:30:50"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -1974,7 +2245,7 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-24T01:30:42"
+      "createdAt" : "2023-11-24T13:30:50"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -2000,13 +2271,13 @@ Content-Length: 1142
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:42"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_6"><a class="link" href="#_response_fields_6">Response Fields</a></h4>
+<h4 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -2249,7 +2520,7 @@ Content-Length: 1142
 <div class="sect2">
 <h3 id="user-change-hero"><a class="link" href="#user-change-hero">유저 히어로 모드 활성화</a></h3>
 <div class="sect3">
-<h4 id="_http_request_7"><a class="link" href="#_http_request_7">HTTP Request</a></h4>
+<h4 id="_http_request_9"><a class="link" href="#_http_request_9">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/me/change-hero HTTP/1.1
@@ -2278,7 +2549,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_7"><a class="link" href="#_http_response_7">HTTP Response</a></h4>
+<h4 id="_http_response_9"><a class="link" href="#_http_response_9">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2290,13 +2561,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:42"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_7"><a class="link" href="#_response_fields_7">Response Fields</a></h4>
+<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -2350,7 +2621,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="user-change-citizen"><a class="link" href="#user-change-citizen">유저 히어로 모드 비활성화</a></h3>
 <div class="sect3">
-<h4 id="_http_request_8"><a class="link" href="#_http_request_8">HTTP Request</a></h4>
+<h4 id="_http_request_10"><a class="link" href="#_http_request_10">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/me/change-citizen HTTP/1.1
@@ -2379,7 +2650,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_8"><a class="link" href="#_http_response_8">HTTP Response</a></h4>
+<h4 id="_http_response_10"><a class="link" href="#_http_response_10">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2391,13 +2662,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:42"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_8"><a class="link" href="#_response_fields_8">Response Fields</a></h4>
+<h4 id="_response_fields_10"><a class="link" href="#_response_fields_10">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -2456,7 +2727,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="profile-citizen-find"><a class="link" href="#profile-citizen-find">시민 프로필 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_9"><a class="link" href="#_http_request_9">HTTP Request</a></h4>
+<h4 id="_http_request_11"><a class="link" href="#_http_request_11">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/users/1/citizen-profile HTTP/1.1
@@ -2485,7 +2756,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_9"><a class="link" href="#_http_response_9">HTTP Response</a></h4>
+<h4 id="_http_response_11"><a class="link" href="#_http_response_11">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2507,13 +2778,13 @@ Content-Length: 335
     },
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_9"><a class="link" href="#_response_fields_9">Response Fields</a></h4>
+<h4 id="_response_fields_11"><a class="link" href="#_response_fields_11">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -2623,7 +2894,7 @@ Content-Length: 335
 <div class="sect2">
 <h3 id="profile-hero-find"><a class="link" href="#profile-hero-find">히어로 프로필 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_10"><a class="link" href="#_http_request_10">HTTP Request</a></h4>
+<h4 id="_http_request_12"><a class="link" href="#_http_request_12">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/users/1/hero-profile HTTP/1.1
@@ -2652,7 +2923,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_10"><a class="link" href="#_http_response_10">HTTP Response</a></h4>
+<h4 id="_http_response_12"><a class="link" href="#_http_response_12">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2691,13 +2962,13 @@ Content-Length: 756
     } ],
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_10"><a class="link" href="#_response_fields_10">Response Fields</a></h4>
+<h4 id="_response_fields_12"><a class="link" href="#_response_fields_12">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -2877,7 +3148,7 @@ Content-Length: 756
 <div class="sect2">
 <h3 id="hero-nickname-search"><a class="link" href="#hero-nickname-search">히어로 닉네임 검색</a></h3>
 <div class="sect3">
-<h4 id="_http_request_11"><a class="link" href="#_http_request_11">HTTP Request</a></h4>
+<h4 id="_http_request_13"><a class="link" href="#_http_request_13">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/users/hero-search?page=0&amp;size=3&amp;nickname=%EB%8B%98 HTTP/1.1
@@ -2914,7 +3185,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_11"><a class="link" href="#_http_response_11">HTTP Response</a></h4>
+<h4 id="_http_response_13"><a class="link" href="#_http_response_13">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -2985,13 +3256,13 @@ Content-Length: 1432
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_11"><a class="link" href="#_response_fields_11">Response Fields</a></h4>
+<h4 id="_response_fields_13"><a class="link" href="#_response_fields_13">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -3246,7 +3517,7 @@ Content-Length: 1432
 <div class="sect2">
 <h3 id="mission-create"><a class="link" href="#mission-create">시민은 미션을 생성 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_12"><a class="link" href="#_http_request_12">HTTP Request</a></h4>
+<h4 id="_http_request_14"><a class="link" href="#_http_request_14">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/missions HTTP/1.1
@@ -3369,7 +3640,7 @@ Content-Type: image/jpeg
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_12"><a class="link" href="#_http_response_12">HTTP Response</a></h4>
+<h4 id="_http_response_14"><a class="link" href="#_http_response_14">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
@@ -3382,13 +3653,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_12"><a class="link" href="#_response_fields_12">Response Fields</a></h4>
+<h4 id="_response_fields_14"><a class="link" href="#_response_fields_14">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -3442,7 +3713,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-findOne"><a class="link" href="#mission-findOne">유저는 미션을 단 건 조회 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_13"><a class="link" href="#_http_request_13">Http Request</a></h4>
+<h4 id="_http_request_15"><a class="link" href="#_http_request_15">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 4. /api/v1/missions/{missionId}</caption>
 <colgroup>
@@ -3490,7 +3761,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_13"><a class="link" href="#_http_response_13">Http Response</a></h4>
+<h4 id="_http_response_15"><a class="link" href="#_http_response_15">Http Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3529,13 +3800,13 @@ Content-Length: 755
     "paths" : [ "path://1", "path://2" ],
     "isBookmarked" : true
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_13"><a class="link" href="#_response_fields_13">Response Fields</a></h4>
+<h4 id="_response_fields_15"><a class="link" href="#_response_fields_15">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -3757,7 +4028,7 @@ Content-Length: 755
 <div class="sect2">
 <h3 id="mission-find-DynamicCondition"><a class="link" href="#mission-find-DynamicCondition">유저는 미션을 필터 조회 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_14"><a class="link" href="#_http_request_14">Http Request</a></h4>
+<h4 id="_http_request_16"><a class="link" href="#_http_request_16">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -3824,7 +4095,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_14"><a class="link" href="#_http_response_14">Http Response</a></h4>
+<h4 id="_http_response_16"><a class="link" href="#_http_response_16">Http Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -3917,13 +4188,13 @@ Content-Length: 2029
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_14"><a class="link" href="#_response_fields_14">Response Fields</a></h4>
+<h4 id="_response_fields_16"><a class="link" href="#_response_fields_16">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -4285,7 +4556,7 @@ Content-Length: 2029
 <div class="sect2">
 <h3 id="mission-progress-find"><a class="link" href="#mission-progress-find">유저는 진행중인 미션을 조회 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_15"><a class="link" href="#_http_request_15">Http Request</a></h4>
+<h4 id="_http_request_17"><a class="link" href="#_http_request_17">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <caption class="title">Table 5. /api/v1/missions/progress/{userId}</caption>
 <colgroup>
@@ -4333,7 +4604,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_15"><a class="link" href="#_http_response_15">Http Response</a></h4>
+<h4 id="_http_response_17"><a class="link" href="#_http_response_17">Http Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4381,13 +4652,13 @@ Content-Length: 874
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_15"><a class="link" href="#_response_fields_15">Response Fields</a></h4>
+<h4 id="_response_fields_17"><a class="link" href="#_response_fields_17">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -4651,26 +4922,7 @@ Content-Length: 874
 <div class="sect2">
 <h3 id="mission-completed-find"><a class="link" href="#mission-completed-find">유저는 완료된 미션을 조회 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_16"><a class="link" href="#_http_request_16">Http Request</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 6. /api/v1/missions/completed/{userId}</caption>
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">시민 아이디</p></td>
-</tr>
-</tbody>
-</table>
+<h4 id="_http_request_18"><a class="link" href="#_http_request_18">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -4699,7 +4951,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_16"><a class="link" href="#_http_response_16">Http Response</a></h4>
+<h4 id="_http_response_18"><a class="link" href="#_http_response_18">Http Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -4747,13 +4999,13 @@ Content-Length: 874
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_16"><a class="link" href="#_response_fields_16">Response Fields</a></h4>
+<h4 id="_response_fields_18"><a class="link" href="#_response_fields_18">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -5017,7 +5269,7 @@ Content-Length: 874
 <div class="sect2">
 <h3 id="mission-ma-find"><a class="link" href="#mission-ma-find">유저는 제안할 미션을 조회할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_17"><a class="link" href="#_http_request_17">Http Request</a></h4>
+<h4 id="_http_request_19"><a class="link" href="#_http_request_19">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 50%;">
@@ -5046,7 +5298,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_http_response_17"><a class="link" href="#_http_response_17">Http Response</a></h4>
+<h4 id="_http_response_19"><a class="link" href="#_http_response_19">Http Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -5104,13 +5356,13 @@ Content-Length: 1276
       "isBookmarked" : true
     } ]
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_17"><a class="link" href="#_response_fields_17">Response Fields</a></h4>
+<h4 id="_response_fields_19"><a class="link" href="#_response_fields_19">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -5304,9 +5556,9 @@ Content-Length: 1276
 <div class="sect2">
 <h3 id="mission-update"><a class="link" href="#mission-update">시민은 미션을 수정 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_18"><a class="link" href="#_http_request_18">Http Request</a></h4>
+<h4 id="_http_request_20"><a class="link" href="#_http_request_20">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 7. /api/v1/missions/{missionId}</caption>
+<caption class="title">Table 6. /api/v1/missions/{missionId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -5440,7 +5692,7 @@ Content-Type: image/jpeg
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_18"><a class="link" href="#_http_response_18">HTTP Response</a></h4>
+<h4 id="_http_response_20"><a class="link" href="#_http_response_20">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -5452,13 +5704,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_18"><a class="link" href="#_response_fields_18">Response Fields</a></h4>
+<h4 id="_response_fields_20"><a class="link" href="#_response_fields_20">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -5512,7 +5764,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-extend"><a class="link" href="#mission-extend">시민은 미션을 연장 할 수 있다.</a></h3>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 8. /api/v1/missions/{missionId}/extend</caption>
+<caption class="title">Table 7. /api/v1/missions/{missionId}/extend</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -5565,7 +5817,7 @@ Host: localhost:8080
 </div>
 </div>
 <div class="sect3">
-<h4 id="_request_fields"><a class="link" href="#_request_fields">Request Fields</a></h4>
+<h4 id="_request_fields_3"><a class="link" href="#_request_fields_3">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -5616,7 +5868,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_19"><a class="link" href="#_http_response_19">HTTP Response</a></h4>
+<h4 id="_http_response_21"><a class="link" href="#_http_response_21">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -5628,13 +5880,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_19"><a class="link" href="#_response_fields_19">Response Fields</a></h4>
+<h4 id="_response_fields_21"><a class="link" href="#_response_fields_21">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -5688,7 +5940,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-complete"><a class="link" href="#mission-complete">시민은 미션을 완료 상태로 변경 할 수 있다.</a></h3>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 9. /api/v1/missions/{missionId}/complete</caption>
+<caption class="title">Table 8. /api/v1/missions/{missionId}/complete</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -5754,7 +6006,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <div class="sect3">
-<h4 id="_http_response_20"><a class="link" href="#_http_response_20">HTTP Response</a></h4>
+<h4 id="_http_response_22"><a class="link" href="#_http_response_22">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -5766,13 +6018,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_20"><a class="link" href="#_response_fields_20">Response Fields</a></h4>
+<h4 id="_response_fields_22"><a class="link" href="#_response_fields_22">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -5826,9 +6078,9 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-delete"><a class="link" href="#mission-delete">시민은 미션을 삭제 할 수 있다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_19"><a class="link" href="#_http_request_19">Http Request</a></h4>
+<h4 id="_http_request_21"><a class="link" href="#_http_request_21">Http Request</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 10. /api/v1/missions/{missionId}</caption>
+<caption class="title">Table 9. /api/v1/missions/{missionId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -5895,7 +6147,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_21"><a class="link" href="#_http_response_21">HTTP Response</a></h4>
+<h4 id="_http_response_23"><a class="link" href="#_http_response_23">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
@@ -5905,13 +6157,13 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_21"><a class="link" href="#_response_fields_21">Response Fields</a></h4>
+<h4 id="_response_fields_23"><a class="link" href="#_response_fields_23">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -5963,7 +6215,7 @@ Content-Length: 81
 <div class="sect2">
 <h3 id="mission-bookmark-create"><a class="link" href="#mission-bookmark-create">미션 찜 등록</a></h3>
 <div class="sect3">
-<h4 id="_http_request_20"><a class="link" href="#_http_request_20">HTTP Request</a></h4>
+<h4 id="_http_request_22"><a class="link" href="#_http_request_22">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/bookmarks HTTP/1.1
@@ -5997,7 +6249,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_2"><a class="link" href="#_request_fields_2">Request Fields</a></h4>
+<h4 id="_request_fields_4"><a class="link" href="#_request_fields_4">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -6027,7 +6279,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_22"><a class="link" href="#_http_response_22">HTTP Response</a></h4>
+<h4 id="_http_response_24"><a class="link" href="#_http_response_24">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -6039,13 +6291,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_22"><a class="link" href="#_response_fields_22">Response Fields</a></h4>
+<h4 id="_response_fields_24"><a class="link" href="#_response_fields_24">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -6099,7 +6351,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="mission-bookmark-cancel"><a class="link" href="#mission-bookmark-cancel">미션 찜 취소</a></h3>
 <div class="sect3">
-<h4 id="_http_request_21"><a class="link" href="#_http_request_21">HTTP Request</a></h4>
+<h4 id="_http_request_23"><a class="link" href="#_http_request_23">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/bookmarks HTTP/1.1
@@ -6133,7 +6385,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_request_fields_3"><a class="link" href="#_request_fields_3">Request Fields</a></h4>
+<h4 id="_request_fields_5"><a class="link" href="#_request_fields_5">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -6163,7 +6415,7 @@ Host: localhost:8080
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_23"><a class="link" href="#_http_response_23">HTTP Response</a></h4>
+<h4 id="_http_response_25"><a class="link" href="#_http_response_25">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
@@ -6173,7 +6425,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
@@ -6233,7 +6485,7 @@ Content-Length: 81
 <div class="sect2">
 <h3 id="mission-match-create"><a class="link" href="#mission-match-create">미션 매치 생성</a></h3>
 <div class="sect3">
-<h4 id="_http_request_22"><a class="link" href="#_http_request_22">HTTP Request</a></h4>
+<h4 id="_http_request_24"><a class="link" href="#_http_request_24">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/mission-matches HTTP/1.1
@@ -6245,291 +6497,6 @@ Host: localhost:8080
 {
   "missionId" : 2,
   "heroId" : 3
-}</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Authorization: Bearer 액세스토큰</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_4"><a class="link" href="#_request_fields_4">Request Fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">path</th>
-<th class="tableblock halign-left valign-top">type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Format</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>heroId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">히어로 아이디</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_http_response_24"><a class="link" href="#_http_response_24">HTTP Response</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 95
-
-{
-  "status" : 201,
-  "data" : {
-    "id" : 1
-  },
-  "serverDateTime" : "2023-11-24T01:30:41"
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_23"><a class="link" href="#_response_fields_23">Response Fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">path</th>
-<th class="tableblock halign-left valign-top">type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Format</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 미션 매칭 아이디</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-<div class="sect2">
-<h3 id="mission-match-cancel"><a class="link" href="#mission-match-cancel">미션 매치 취소</a></h3>
-<div class="sect3">
-<h4 id="_http_request_23"><a class="link" href="#_http_request_23">HTTP Request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/mission-matches/cancel HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
-Content-Length: 21
-Host: localhost:8080
-
-{
-  "missionId" : 2
-}</code></pre>
-</div>
-</div>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">Name</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">Authorization: Bearer 액세스토큰</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_request_fields_5"><a class="link" href="#_request_fields_5">Request Fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">path</th>
-<th class="tableblock halign-left valign-top">type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Format</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-<div class="sect3">
-<h4 id="_http_response_25"><a class="link" href="#_http_response_25">HTTP Response</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Content-Type: application/json;charset=UTF-8
-Content-Length: 95
-
-{
-  "status" : 200,
-  "data" : {
-    "id" : 1
-  },
-  "serverDateTime" : "2023-11-24T01:30:41"
-}</code></pre>
-</div>
-</div>
-</div>
-<div class="sect3">
-<h4 id="_response_fields_24"><a class="link" href="#_response_fields_24">Response Fields</a></h4>
-<table class="tableblock frame-all grid-all stretch">
-<colgroup>
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-<col style="width: 20%;">
-</colgroup>
-<thead>
-<tr>
-<th class="tableblock halign-left valign-top">path</th>
-<th class="tableblock halign-left valign-top">type</th>
-<th class="tableblock halign-left valign-top">Optional</th>
-<th class="tableblock halign-left valign-top">Format</th>
-<th class="tableblock halign-left valign-top">Description</th>
-</tr>
-</thead>
-<tbody>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">취소된 미션 매칭 아이디</p></td>
-</tr>
-<tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
-<td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
-</tr>
-</tbody>
-</table>
-</div>
-</div>
-</div>
-</div>
-<div class="sect1">
-<h2 id="Mission-proposal-API"><a class="link" href="#Mission-proposal-API">Mission Proposal API</a></h2>
-<div class="sectionbody">
-<div class="sect2">
-<h3 id="mission-proposal-create"><a class="link" href="#mission-proposal-create">미션 제안 생성</a></h3>
-<div class="sect3">
-<h4 id="_http_request_24"><a class="link" href="#_http_request_24">HTTP Request</a></h4>
-<div class="listingblock">
-<div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/mission-proposals HTTP/1.1
-Content-Type: application/json;charset=UTF-8
-Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
-Content-Length: 37
-Host: localhost:8080
-
-{
-  "missionId" : 1,
-  "heroId" : 1
 }</code></pre>
 </div>
 </div>
@@ -6593,8 +6560,7 @@ Host: localhost:8080
 <h4 id="_http_response_26"><a class="link" href="#_http_response_26">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Location: /api/v1/mission-proposals/1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
 Content-Length: 95
 
@@ -6603,7 +6569,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
@@ -6647,7 +6613,7 @@ Content-Length: 95
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">미션 제안 아이디</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">생성된 미션 매칭 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
@@ -6661,14 +6627,20 @@ Content-Length: 95
 </div>
 </div>
 <div class="sect2">
-<h3 id="mission-proposal-approve"><a class="link" href="#mission-proposal-approve">미션 제안 승낙</a></h3>
+<h3 id="mission-match-cancel"><a class="link" href="#mission-match-cancel">미션 매치 취소</a></h3>
 <div class="sect3">
 <h4 id="_http_request_25"><a class="link" href="#_http_request_25">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/mission-proposals/1/approve HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PUT /api/v1/mission-matches/cancel HTTP/1.1
+Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
-Host: localhost:8080</code></pre>
+Content-Length: 21
+Host: localhost:8080
+
+{
+  "missionId" : 2
+}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -6689,22 +6661,33 @@ Host: localhost:8080</code></pre>
 </tr>
 </tbody>
 </table>
+</div>
+<div class="sect3">
+<h4 id="_request_fields_7"><a class="link" href="#_request_fields_7">Request Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 11. /api/v1/mission-proposals/{missionProposalId}/approve</caption>
 <colgroup>
-<col style="width: 50%;">
-<col style="width: 50%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
 </colgroup>
 <thead>
 <tr>
-<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
 <th class="tableblock halign-left valign-top">Description</th>
 </tr>
 </thead>
 <tbody>
 <tr>
-<td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionProposalId</code></p></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">미션 제안 아이디</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
 </tr>
 </tbody>
 </table>
@@ -6722,7 +6705,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
@@ -6766,7 +6749,7 @@ Content-Length: 95
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"></td>
-<td class="tableblock halign-left valign-top"><p class="tableblock">미션 제안 아이디</p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">취소된 미션 매칭 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
@@ -6779,15 +6762,27 @@ Content-Length: 95
 </table>
 </div>
 </div>
+</div>
+</div>
+<div class="sect1">
+<h2 id="Mission-proposal-API"><a class="link" href="#Mission-proposal-API">Mission Proposal API</a></h2>
+<div class="sectionbody">
 <div class="sect2">
-<h3 id="mission-proposal-reject"><a class="link" href="#mission-proposal-reject">미션 제안 거절</a></h3>
+<h3 id="mission-proposal-create"><a class="link" href="#mission-proposal-create">미션 제안 생성</a></h3>
 <div class="sect3">
 <h4 id="_http_request_26"><a class="link" href="#_http_request_26">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/mission-proposals/1/reject HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/mission-proposals HTTP/1.1
+Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
-Host: localhost:8080</code></pre>
+Content-Length: 37
+Host: localhost:8080
+
+{
+  "missionId" : 1,
+  "heroId" : 1
+}</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -6810,19 +6805,57 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
+<h4 id="_request_fields_8"><a class="link" href="#_request_fields_8">Request Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>heroId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">히어로 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
 <h4 id="_http_response_28"><a class="link" href="#_http_response_28">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Location: /api/v1/mission-proposals/1
 Content-Type: application/json;charset=UTF-8
 Content-Length: 95
 
 {
-  "status" : 200,
+  "status" : 201,
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
@@ -6880,9 +6913,228 @@ Content-Length: 95
 </div>
 </div>
 <div class="sect2">
-<h3 id="mission-proposal-find"><a class="link" href="#mission-proposal-find">제안받은 미션 조회</a></h3>
+<h3 id="mission-proposal-approve"><a class="link" href="#mission-proposal-approve">미션 제안 승낙</a></h3>
 <div class="sect3">
 <h4 id="_http_request_27"><a class="link" href="#_http_request_27">HTTP Request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/mission-proposals/1/approve HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Authorization: Bearer 액세스토큰</p></td>
+</tr>
+</tbody>
+</table>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 10. /api/v1/mission-proposals/{missionProposalId}/approve</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionProposalId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 제안 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_http_response_29"><a class="link" href="#_http_response_29">HTTP Response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 95
+
+{
+  "status" : 200,
+  "data" : {
+    "id" : 1
+  },
+  "serverDateTime" : "2023-11-24T13:30:50"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_28"><a class="link" href="#_response_fields_28">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 제안 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="mission-proposal-reject"><a class="link" href="#mission-proposal-reject">미션 제안 거절</a></h3>
+<div class="sect3">
+<h4 id="_http_request_28"><a class="link" href="#_http_request_28">HTTP Request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/mission-proposals/1/reject HTTP/1.1
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Name</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Authorization</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">Authorization: Bearer 액세스토큰</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_http_response_30"><a class="link" href="#_http_response_30">HTTP Response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 95
+
+{
+  "status" : 200,
+  "data" : {
+    "id" : 1
+  },
+  "serverDateTime" : "2023-11-24T13:30:50"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_29"><a class="link" href="#_response_fields_29">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 제안 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="mission-proposal-find"><a class="link" href="#mission-proposal-find">제안받은 미션 조회</a></h3>
+<div class="sect3">
+<h4 id="_http_request_29"><a class="link" href="#_http_request_29">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/mission-proposals?page=0&amp;size=5 HTTP/1.1
@@ -6937,7 +7189,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_29"><a class="link" href="#_http_response_29">HTTP Response</a></h4>
+<h4 id="_http_response_31"><a class="link" href="#_http_response_31">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -6954,7 +7206,7 @@ Content-Length: 3909
         "status" : "MATCHING",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-24T01:30:41",
+        "createdAt" : "2023-11-24T13:30:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -6980,7 +7232,7 @@ Content-Length: 3909
         "status" : "MATCHING",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-23T01:30:41",
+        "createdAt" : "2023-11-23T13:30:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7006,7 +7258,7 @@ Content-Length: 3909
         "status" : "MATCHING_COMPLETED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-21T01:30:41",
+        "createdAt" : "2023-11-21T13:30:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7032,7 +7284,7 @@ Content-Length: 3909
         "status" : "MISSION_COMPLETED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-22T01:30:41",
+        "createdAt" : "2023-11-22T13:30:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7058,7 +7310,7 @@ Content-Length: 3909
         "status" : "EXPIRED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-21T01:30:41",
+        "createdAt" : "2023-11-21T13:30:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7102,13 +7354,13 @@ Content-Length: 3909
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_28"><a class="link" href="#_response_fields_28">Response Fields</a></h4>
+<h4 id="_response_fields_30"><a class="link" href="#_response_fields_30">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -7447,7 +7699,7 @@ Content-Length: 3909
 <div class="sect2">
 <h3 id="review-create"><a class="link" href="#review-create">리뷰 생성</a></h3>
 <div class="sect3">
-<h4 id="_http_request_28"><a class="link" href="#_http_request_28">HTTP Request</a></h4>
+<h4 id="_http_request_30"><a class="link" href="#_http_request_30">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviews HTTP/1.1
@@ -7527,7 +7779,7 @@ Content-Type: image/jpeg
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_30"><a class="link" href="#_http_response_30">HTTP Response</a></h4>
+<h4 id="_http_response_32"><a class="link" href="#_http_response_32">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
@@ -7540,13 +7792,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_29"><a class="link" href="#_response_fields_29">Response Fields</a></h4>
+<h4 id="_response_fields_31"><a class="link" href="#_response_fields_31">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -7600,7 +7852,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="review-update"><a class="link" href="#review-update">리뷰 수정</a></h3>
 <div class="sect3">
-<h4 id="_http_request_29"><a class="link" href="#_http_request_29">HTTP Request</a></h4>
+<h4 id="_http_request_31"><a class="link" href="#_http_request_31">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/reviews/1 HTTP/1.1
@@ -7650,7 +7902,7 @@ Content-Type: image/jpeg
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_31"><a class="link" href="#_http_response_31">HTTP Response</a></h4>
+<h4 id="_http_response_33"><a class="link" href="#_http_response_33">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -7662,13 +7914,13 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_30"><a class="link" href="#_response_fields_30">Response Fields</a></h4>
+<h4 id="_response_fields_32"><a class="link" href="#_response_fields_32">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -7722,7 +7974,7 @@ Content-Length: 95
 <div class="sect2">
 <h3 id="_리뷰_상세_조회"><a class="link" href="#_리뷰_상세_조회">리뷰 상세 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_30"><a class="link" href="#_http_request_30">HTTP Request</a></h4>
+<h4 id="_http_request_32"><a class="link" href="#_http_request_32">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/1 HTTP/1.1
@@ -7732,7 +7984,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 12. /api/v1/reviews/{reviewId}</caption>
+<caption class="title">Table 11. /api/v1/reviews/{reviewId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7752,7 +8004,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_32"><a class="link" href="#_http_response_32">HTTP Response</a></h4>
+<h4 id="_http_response_34"><a class="link" href="#_http_response_34">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -7783,15 +8035,15 @@ Content-Length: 719
       "uniqueName" : "B",
       "path" : "S3 이미지 주소B"
     } ],
-    "createdAt" : "2023-11-24T01:30:41"
+    "createdAt" : "2023-11-24T13:30:50"
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_31"><a class="link" href="#_response_fields_31">Response Fields</a></h4>
+<h4 id="_response_fields_33"><a class="link" href="#_response_fields_33">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -7950,7 +8202,7 @@ Content-Length: 719
 <div class="sect2">
 <h3 id="_리뷰_삭제"><a class="link" href="#_리뷰_삭제">리뷰 삭제</a></h3>
 <div class="sect3">
-<h4 id="_http_request_31"><a class="link" href="#_http_request_31">HTTP Request</a></h4>
+<h4 id="_http_request_33"><a class="link" href="#_http_request_33">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/reviews/1 HTTP/1.1
@@ -7959,7 +8211,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 13. /api/v1/reviews/{reviewId}</caption>
+<caption class="title">Table 12. /api/v1/reviews/{reviewId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -7979,7 +8231,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_33"><a class="link" href="#_http_response_33">HTTP Response</a></h4>
+<h4 id="_http_response_35"><a class="link" href="#_http_response_35">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
@@ -7989,7 +8241,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
@@ -7998,7 +8250,7 @@ Content-Length: 81
 <div class="sect2">
 <h3 id="specific-user-received-reviews"><a class="link" href="#specific-user-received-reviews">특정 유저가 받은 리뷰 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_32"><a class="link" href="#_http_request_32">HTTP Request</a></h4>
+<h4 id="_http_request_34"><a class="link" href="#_http_request_34">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/reviews/users/1/receive?page=0&amp;size=5&amp;sort= HTTP/1.1
@@ -8009,7 +8261,7 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 14. /api/v1/reviews/users/{userId}/receive</caption>
+<caption class="title">Table 13. /api/v1/reviews/users/{userId}/receive</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -8055,7 +8307,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_34"><a class="link" href="#_http_response_34">HTTP Response</a></h4>
+<h4 id="_http_response_36"><a class="link" href="#_http_response_36">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -8073,7 +8325,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-24T01:30:41"
+      "createdAt" : "2023-11-24T13:30:50"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -8082,7 +8334,7 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-24T01:30:41"
+      "createdAt" : "2023-11-24T13:30:50"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -8108,13 +8360,13 @@ Content-Length: 1142
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:41"
+  "serverDateTime" : "2023-11-24T13:30:50"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_32"><a class="link" href="#_response_fields_32">Response Fields</a></h4>
+<h4 id="_response_fields_34"><a class="link" href="#_response_fields_34">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -8362,7 +8614,7 @@ Content-Length: 1142
 <div class="sect2">
 <h3 id="main-page"><a class="link" href="#main-page">메인 페이지를 조회한다.</a></h3>
 <div class="sect3">
-<h4 id="_http_request_33"><a class="link" href="#_http_request_33">HTTP Request</a></h4>
+<h4 id="_http_request_35"><a class="link" href="#_http_request_35">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/main?longitude=127.02880308004335&amp;latitude=37.49779692073204 HTTP/1.1
@@ -8413,7 +8665,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_35"><a class="link" href="#_http_response_35">HTTP Response</a></h4>
+<h4 id="_http_response_37"><a class="link" href="#_http_response_37">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -8476,13 +8728,13 @@ Content-Length: 1299
       "isBookmarked" : false
     } ]
   },
-  "serverDateTime" : "2023-11-24T01:30:40"
+  "serverDateTime" : "2023-11-24T13:30:49"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_33"><a class="link" href="#_response_fields_33">Response Fields</a></h4>
+<h4 id="_response_fields_35"><a class="link" href="#_response_fields_35">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -8674,7 +8926,7 @@ Content-Length: 1299
 <div class="sect2">
 <h3 id="sse-subscribe"><a class="link" href="#sse-subscribe">SSE 구독</a></h3>
 <div class="sect3">
-<h4 id="_http_request_34"><a class="link" href="#_http_request_34">HTTP Request</a></h4>
+<h4 id="_http_request_36"><a class="link" href="#_http_request_36">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/sse/subscribe HTTP/1.1
@@ -8703,7 +8955,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_36"><a class="link" href="#_http_response_36">HTTP Response</a></h4>
+<h4 id="_http_response_38"><a class="link" href="#_http_response_38">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK</code></pre>
@@ -8719,7 +8971,7 @@ Host: localhost:8080</code></pre>
 <div class="sect2">
 <h3 id="alarm-find"><a class="link" href="#alarm-find">알림 조회</a></h3>
 <div class="sect3">
-<h4 id="_http_request_35"><a class="link" href="#_http_request_35">HTTP Request</a></h4>
+<h4 id="_http_request_37"><a class="link" href="#_http_request_37">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/alarms HTTP/1.1
@@ -8748,7 +9000,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_37"><a class="link" href="#_http_response_37">HTTP Response</a></h4>
+<h4 id="_http_response_39"><a class="link" href="#_http_response_39">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
@@ -8759,22 +9011,22 @@ Content-Length: 1245
   "status" : 200,
   "data" : {
     "content" : [ {
-      "id" : "5fc4eb84-40ee-4c80-bb05-dbb07fe161ca",
+      "id" : "43f55e54-519e-4a61-95f5-e8b633f94e03",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-21T12:00:00"
     }, {
-      "id" : "1cd1ce8a-07bd-4157-b806-27236f6db96c",
+      "id" : "99f42f0d-1560-4b7e-b85b-ee54d7ac062c",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-21T10:00:00"
     }, {
-      "id" : "5c47fd60-4171-4f23-a8f3-52699e6904f8",
+      "id" : "4e8ae5e9-6f21-43ba-9ee0-3a6b3308d9bd",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-20T12:00:00"
     }, {
-      "id" : "d45cb353-41cb-4a28-8b04-2cc62589e458",
+      "id" : "2ea13dc8-7c5c-4c38-aaa0-cf60f262e8f5",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-14T12:00:00"
@@ -8803,13 +9055,13 @@ Content-Length: 1245
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T01:30:39"
+  "serverDateTime" : "2023-11-24T13:30:48"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_34"><a class="link" href="#_response_fields_34">Response Fields</a></h4>
+<h4 id="_response_fields_36"><a class="link" href="#_response_fields_36">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -9024,10 +9276,10 @@ Content-Length: 1245
 <div class="sect2">
 <h3 id="alarm-delete"><a class="link" href="#alarm-delete">알림 삭제</a></h3>
 <div class="sect3">
-<h4 id="_http_request_36"><a class="link" href="#_http_request_36">HTTP Request</a></h4>
+<h4 id="_http_request_38"><a class="link" href="#_http_request_38">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/alarms/98c6fff1-1259-4a68-9660-ca93df45b3bd HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/alarms/c3f1cb78-011f-4406-95ae-394909fb4704 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
 Host: localhost:8080</code></pre>
@@ -9052,7 +9304,7 @@ Host: localhost:8080</code></pre>
 </tbody>
 </table>
 <table class="tableblock frame-all grid-all stretch">
-<caption class="title">Table 15. /api/v1/alarms/{alarmId}</caption>
+<caption class="title">Table 14. /api/v1/alarms/{alarmId}</caption>
 <colgroup>
 <col style="width: 50%;">
 <col style="width: 50%;">
@@ -9072,7 +9324,7 @@ Host: localhost:8080</code></pre>
 </table>
 </div>
 <div class="sect3">
-<h4 id="_http_response_38"><a class="link" href="#_http_response_38">HTTP Response</a></h4>
+<h4 id="_http_response_40"><a class="link" href="#_http_response_40">HTTP Response</a></h4>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 204 No Content
@@ -9082,13 +9334,13 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T01:30:39"
+  "serverDateTime" : "2023-11-24T13:30:48"
 }</code></pre>
 </div>
 </div>
 </div>
 <div class="sect3">
-<h4 id="_response_fields_35"><a class="link" href="#_response_fields_35">Response Fields</a></h4>
+<h4 id="_response_fields_37"><a class="link" href="#_response_fields_37">Response Fields</a></h4>
 <table class="tableblock frame-all grid-all stretch">
 <colgroup>
 <col style="width: 20%;">
@@ -9134,11 +9386,456 @@ Content-Length: 81
 </div>
 </div>
 </div>
+<div class="sect1">
+<h2 id="Chatroom-API"><a class="link" href="#Chatroom-API">Chatroom API</a></h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="chatroom-create"><a class="link" href="#chatroom-create">시민은 채팅방을 만들 수 있다.</a></h3>
+<div class="sect3">
+<h4 id="_http_request_39"><a class="link" href="#_http_request_39">HTTP Request</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/chat-rooms HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 45
+Host: localhost:8080
+
+{
+  "missionId" : 1,
+  "userIds" : [ 1, 2 ]
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_request_fields_9"><a class="link" href="#_request_fields_9">Request Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>missionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userIds</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">채팅방에 들어갈 유저 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_http_response_41"><a class="link" href="#_http_response_41">HTTP Response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
+Location: /api/v1/chat-rooms/1
+Content-Type: application/json;charset=UTF-8
+Content-Length: 137
+
+{
+  "status" : 201,
+  "data" : {
+    "id" : 1,
+    "missionId" : 1,
+    "headCount" : 2
+  },
+  "serverDateTime" : "2023-11-24T13:30:48"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_38"><a class="link" href="#_response_fields_38">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">채팅방 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.missionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.headCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">채팅방 인원 수</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="chatRoom-joined"><a class="link" href="#chatRoom-joined">유저는 현재 자신이 들어가 있는 채팅방을 조회 할 수 있다.</a></h3>
+<div class="sect3">
+<h4 id="_http_request_40"><a class="link" href="#_http_request_40">HTTP Request</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 15. /api/v1/chat-rooms/users/{userId}</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_http_response_42"><a class="link" href="#_http_response_42">HTTP Response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 720
+
+{
+  "status" : 200,
+  "data" : [ {
+    "id" : 1,
+    "receiverId" : 1,
+    "title" : "심부름 해주실 분을 찾습니다.",
+    "receiverNickname" : "슈퍼 히어로 토끼 A",
+    "receiverImagePath" : "s3://abc.jpeg",
+    "lastSentMessage" : "거의 다 와갑니다!",
+    "headCount" : 1,
+    "lastSentMessageTime" : "2023-11-12T12:00:00"
+  }, {
+    "id" : 2,
+    "receiverId" : 2,
+    "title" : "벌레 잡아주실 분을 찾습니다.",
+    "receiverNickname" : "슈퍼 히어로 토끼 B",
+    "receiverImagePath" : "s3://abd.jpeg",
+    "lastSentMessage" : "어떤 벌레인가요?",
+    "headCount" : 2,
+    "lastSentMessageTime" : "2023-11-12T12:00:00"
+  } ],
+  "serverDateTime" : "2023-11-24T13:30:48"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_39"><a class="link" href="#_response_fields_39">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[]</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Array</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">채팅방 조회 배열</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">채팅방 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].title</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].receiverId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수신자 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].receiverNickname</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수신자 닉네임</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].receiverImagePath</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">수신자 프로필 이미지 경로</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].lastSentMessage</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막으로 받은 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].lastSentMessageTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">마지막으로 받은 메시지 시간</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].headCount</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">채팅방 인원</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+<div class="sect2">
+<h3 id="chatRoom-exit"><a class="link" href="#chatRoom-exit">유저는 현재 자신이 들어가 있는 채팅방을 나갈 수 있다.</a></h3>
+<div class="sect3">
+<h4 id="_http_request_41"><a class="link" href="#_http_request_41">HTTP Request</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<caption class="title">Table 16. /api/v1/chat-rooms/{chatRoomId}/exit</caption>
+<colgroup>
+<col style="width: 50%;">
+<col style="width: 50%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Parameter</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>chatRoomId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">채팅방 아이디</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">PATCH /api/v1/chat-rooms/1/exit HTTP/1.1
+Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
+Host: localhost:8080</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 아이디</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect3">
+<h4 id="_http_response_43"><a class="link" href="#_http_response_43">HTTP Response</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json;charset=UTF-8
+Content-Length: 134
+
+{
+  "status" : 200,
+  "data" : {
+    "id" : 1,
+    "userId" : 1,
+    "missionId" : 1
+  },
+  "serverDateTime" : "2023-11-24T13:30:48"
+}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_fields_40"><a class="link" href="#_response_fields_40">Response Fields</a></h4>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+<col style="width: 20%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">path</th>
+<th class="tableblock halign-left valign-top">type</th>
+<th class="tableblock halign-left valign-top">Optional</th>
+<th class="tableblock halign-left valign-top">Format</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>status</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">HTTP 응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 데이터</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">채팅방 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.missionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.userId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저 아이디</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>serverDateTime</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>yyyy-MM-dd'T'HH:mm:ss</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">서버 응답 시간</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-11-23 15:21:48 +0900
+Last updated 2023-11-24 13:29:23 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/chatroom/response/MissionChatRoomFindResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/chatroom/response/MissionChatRoomFindResponse.java
@@ -2,6 +2,7 @@ package com.sixheroes.onedayheroapplication.chatroom.response;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.sixheroes.onedayherodomain.missionchatroom.repository.response.UserChatRoomQueryResponse;
+import com.sixheroes.onedayheromongo.chat.ChatMessage;
 import lombok.Builder;
 
 import java.time.LocalDateTime;
@@ -26,14 +27,19 @@ public record MissionChatRoomFindResponse(
         LocalDateTime lastSentMessageTime
 
 ) {
-    public static MissionChatRoomFindResponse from(UserChatRoomQueryResponse queryResponse) {
+    public static MissionChatRoomFindResponse from(
+            UserChatRoomQueryResponse queryResponse,
+            ChatMessage chatMessage
+    ) {
         return MissionChatRoomFindResponse.builder()
                 .id(queryResponse.chatRoomId())
                 .receiverId(queryResponse.receiverId())
                 .title(queryResponse.title())
                 .receiverNickname(queryResponse.nickName())
                 .receiverImagePath(queryResponse.path())
+                .lastSentMessage(chatMessage.getMessage())
                 .headCount(queryResponse.headCount())
+                .lastSentMessageTime(chatMessage.getSentMessageTime())
                 .build();
     }
 }

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/UserMissionChatRoom.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/UserMissionChatRoom.java
@@ -47,7 +47,7 @@ public class UserMissionChatRoom {
                 .build();
     }
 
-    public boolean isFindByUserId(Long userId) {
+    public boolean isUserChatRoom(Long userId) {
         return this.userId.equals(userId);
     }
 

--- a/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/chat/repository/ChatMessageMongoRepository.java
+++ b/onedayhero-mongo/src/main/java/com/sixheroes/onedayheromongo/chat/repository/ChatMessageMongoRepository.java
@@ -1,0 +1,37 @@
+package com.sixheroes.onedayheromongo.chat.repository;
+
+import com.sixheroes.onedayheromongo.chat.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RequiredArgsConstructor
+@Repository
+public class ChatMessageMongoRepository {
+
+    private final MongoTemplate mongoTemplate;
+
+    public List<ChatMessage> findLatestMessagesByChatRoomIds(
+            List<Long> chatRoomIds
+    ) {
+        List<ChatMessage> latestMessages = new ArrayList<>();
+
+        for (Long chatRoomId : chatRoomIds) {
+            Query query = new Query(Criteria.where("chat_room_id").is(chatRoomId));
+            query.with(Sort.by(Sort.Direction.DESC, "sent_message_time"));
+            query.limit(1);
+            ChatMessage latestMessage = mongoTemplate.findOne(query, ChatMessage.class);
+            if (latestMessage != null) {
+                latestMessages.add(latestMessage);
+            }
+        }
+
+        return latestMessages;
+    }
+}


### PR DESCRIPTION
## 🖊️ 1. Changes
- 현재 참여중인 채팅방을 조회하는 로직에서 마지막으로 받은 메시지와 받은 시간을 보내는 로직을 추가하였습니다.
- MongoDB에서 Collections의 메시지를 가지고 오기 위해 MongoTemplate를 사용하였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- 참여중인 채팅방을 조회하는 로직이 상당히 복잡한 것 같습니다..!
1. 현재 유저가 참여중인 채팅방을 조회한다.
2. 현재 유저가 참여중인 채팅방에 상대방의 아이디를 조회한다.
3. 상대방의 아이디에 맞는 필요한 유저 정보를 가지고 온다.
4. 현재 유저가 참여중인 채팅방의 마지막 메시지 정보를 가지고 온다.
5. 위에서 가지고온 채팅방 별 정보와 채팅방의 마지막 메시지를 합친다
6. 반환

## ✅ 5. Plans
- [ ] - 참여중인 채팅방 조회 서비스 로직 테스트

## 🙌 6. Checklist
- [X] - 통합 테스트를 수행해보셨나요?
- [X] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [X] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
