### PR TITLE
[SIX-263] 채팅방 조회 시 필요한 프론트 요청 데이터 추가 및 테스트 코드 수정

### DIFF
--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/chatroom/ChatRoomController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/chatroom/ChatRoomController.java
@@ -7,6 +7,8 @@ import com.sixheroes.onedayheroapplication.chatroom.ChatRoomService;
 import com.sixheroes.onedayheroapplication.chatroom.response.MissionChatRoomCreateResponse;
 import com.sixheroes.onedayheroapplication.chatroom.response.MissionChatRoomExitResponse;
 import com.sixheroes.onedayheroapplication.chatroom.response.MissionChatRoomFindResponse;
+import com.sixheroes.onedayherochat.application.ChatService;
+import com.sixheroes.onedayherochat.application.response.ChatMessageApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -22,6 +24,7 @@ public class ChatRoomController {
 
     private static final String CHAT_ROOM_URI_FORMAT = "/api/v1/chat-rooms/";
     private final ChatRoomService chatRoomService;
+    private final ChatService chatService;
 
     @PostMapping
     public ResponseEntity<ApiResponse<MissionChatRoomCreateResponse>> createChatRoom(
@@ -32,11 +35,19 @@ public class ChatRoomController {
                 .body(ApiResponse.created(result));
     }
 
-    @GetMapping("/users")
+    @GetMapping("/me")
     public ResponseEntity<ApiResponse<List<MissionChatRoomFindResponse>>> findByChatRoomId(
             @AuthUser Long userId
     ) {
         var result = chatRoomService.findJoinedChatRoom(userId);
+        return ResponseEntity.ok(ApiResponse.ok(result));
+    }
+
+    @GetMapping("/{chatRoomId}")
+    public ResponseEntity<ApiResponse<List<ChatMessageApiResponse>>> findChatMessagesByChatRoomId(
+            @PathVariable Long chatRoomId
+    ) {
+        var result = chatService.findMessageByChatRoomId(chatRoomId);
         return ResponseEntity.ok(ApiResponse.ok(result));
     }
 

--- a/onedayhero-api/src/main/resources/static/docs/index.html
+++ b/onedayhero-api/src/main/resources/static/docs/index.html
@@ -602,7 +602,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Set-Cookie: refreshToken=d93f8dc0-9d8c-467d-be03-f4acd0192eae; HttpOnly
+Set-Cookie: refreshToken=1c49228c-ef4e-4692-ad1e-509a32afa9a3; HttpOnly
 Location:
 Content-Type: application/json;charset=UTF-8
 Content-Length: 134
@@ -613,7 +613,7 @@ Content-Length: 134
     "userId" : 1,
     "accessToken" : "accessToken"
   },
-  "serverDateTime" : "2023-11-24T16:38:23"
+  "serverDateTime" : "2023-11-26T19:19:48"
 }</code></pre>
 </div>
 </div>
@@ -729,7 +729,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: refreshToken=133f4e77-7bfe-48ef-b0f8-e124cb59f26a; HttpOnly
+Set-Cookie: refreshToken=9b9714f9-9b64-456f-aff9-7a3c5c974dd9; HttpOnly
 Content-Type: application/json;charset=UTF-8
 Content-Length: 134
 
@@ -739,7 +739,7 @@ Content-Length: 134
     "userId" : 1,
     "accessToken" : "accessToken"
   },
-  "serverDateTime" : "2023-11-24T16:38:23"
+  "serverDateTime" : "2023-11-26T19:19:48"
 }</code></pre>
 </div>
 </div>
@@ -880,7 +880,7 @@ Content-Length: 781
     "heroScore" : 30,
     "isHeroMode" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -1193,7 +1193,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -1311,7 +1311,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -1493,8 +1493,8 @@ Content-Length: 2193
         "pageSize" : 3,
         "sort" : {
           "empty" : true,
-          "unsorted" : true,
-          "sorted" : false
+          "sorted" : false,
+          "unsorted" : true
         },
         "offset" : 0,
         "paged" : true,
@@ -1504,16 +1504,16 @@ Content-Length: 2193
       "number" : 0,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
+      "numberOfElements" : 3,
       "first" : true,
       "last" : false,
-      "numberOfElements" : 3,
       "empty" : false
     }
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -1891,7 +1891,7 @@ Content-Length: 1130
       "starScore" : 3,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-24T16:38:25"
+      "createdAt" : "2023-11-26T19:19:51"
     }, {
       "reviewId" : 2,
       "categoryName" : "청소",
@@ -1899,15 +1899,15 @@ Content-Length: 1130
       "starScore" : 4,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-24T16:38:25"
+      "createdAt" : "2023-11-26T19:19:51"
     } ],
     "pageable" : {
       "pageNumber" : 0,
       "pageSize" : 5,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
       "paged" : true,
@@ -1917,15 +1917,15 @@ Content-Length: 1130
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
+    "numberOfElements" : 2,
     "first" : true,
     "last" : false,
-    "numberOfElements" : 2,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -2241,7 +2241,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-24T16:38:25"
+      "createdAt" : "2023-11-26T19:19:51"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -2250,15 +2250,15 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-24T16:38:25"
+      "createdAt" : "2023-11-26T19:19:51"
     } ],
     "pageable" : {
       "pageNumber" : 0,
       "pageSize" : 5,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
       "paged" : true,
@@ -2268,15 +2268,15 @@ Content-Length: 1142
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
+    "numberOfElements" : 2,
     "first" : true,
     "last" : false,
-    "numberOfElements" : 2,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -2566,7 +2566,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -2667,7 +2667,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -2783,7 +2783,7 @@ Content-Length: 335
     },
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -2967,7 +2967,7 @@ Content-Length: 756
     } ],
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -3242,8 +3242,8 @@ Content-Length: 1432
       "pageSize" : 3,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
       "paged" : true,
@@ -3253,15 +3253,15 @@ Content-Length: 1432
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
+    "numberOfElements" : 3,
     "first" : true,
     "last" : false,
-    "numberOfElements" : 3,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:25"
+  "serverDateTime" : "2023-11-26T19:19:51"
 }</code></pre>
 </div>
 </div>
@@ -3658,7 +3658,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -3805,7 +3805,7 @@ Content-Length: 755
     "paths" : [ "path://1", "path://2" ],
     "isBookmarked" : true
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -4174,8 +4174,8 @@ Content-Length: 2029
       "pageSize" : 4,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
       "paged" : true,
@@ -4185,15 +4185,15 @@ Content-Length: 2029
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
+    "numberOfElements" : 2,
     "first" : true,
     "last" : true,
-    "numberOfElements" : 2,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -4638,8 +4638,8 @@ Content-Length: 874
       "pageSize" : 4,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
       "paged" : true,
@@ -4649,15 +4649,15 @@ Content-Length: 874
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
+    "numberOfElements" : 1,
     "first" : true,
     "last" : true,
-    "numberOfElements" : 1,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -4985,8 +4985,8 @@ Content-Length: 874
       "pageSize" : 4,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
       "paged" : true,
@@ -4996,15 +4996,15 @@ Content-Length: 874
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
+    "numberOfElements" : 1,
     "first" : true,
     "last" : true,
-    "numberOfElements" : 1,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -5361,7 +5361,7 @@ Content-Length: 1276
       "isBookmarked" : true
     } ]
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -5709,7 +5709,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -5885,7 +5885,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -6023,7 +6023,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -6162,7 +6162,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -6296,7 +6296,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:23"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -6430,7 +6430,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T16:38:23"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -6574,7 +6574,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -6710,7 +6710,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -6860,7 +6860,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -6979,7 +6979,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -7079,7 +7079,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -7211,7 +7211,7 @@ Content-Length: 3909
         "status" : "MATCHING",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-24T16:38:24",
+        "createdAt" : "2023-11-26T19:19:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7237,7 +7237,7 @@ Content-Length: 3909
         "status" : "MATCHING",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-23T16:38:24",
+        "createdAt" : "2023-11-25T19:19:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7263,7 +7263,7 @@ Content-Length: 3909
         "status" : "MATCHING_COMPLETED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-21T16:38:24",
+        "createdAt" : "2023-11-23T19:19:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7289,7 +7289,7 @@ Content-Length: 3909
         "status" : "MISSION_COMPLETED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-22T16:38:24",
+        "createdAt" : "2023-11-24T19:19:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7315,7 +7315,7 @@ Content-Length: 3909
         "status" : "EXPIRED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-21T16:38:24",
+        "createdAt" : "2023-11-23T19:19:50",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7340,8 +7340,8 @@ Content-Length: 3909
       "pageSize" : 5,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
       "paged" : true,
@@ -7351,15 +7351,15 @@ Content-Length: 3909
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
+    "numberOfElements" : 5,
     "first" : true,
     "last" : false,
-    "numberOfElements" : 5,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -7797,7 +7797,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -7919,7 +7919,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -8040,9 +8040,9 @@ Content-Length: 719
       "uniqueName" : "B",
       "path" : "S3 이미지 주소B"
     } ],
-    "createdAt" : "2023-11-24T16:38:24"
+    "createdAt" : "2023-11-26T19:19:50"
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -8246,7 +8246,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -8330,7 +8330,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-24T16:38:24"
+      "createdAt" : "2023-11-26T19:19:50"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -8339,15 +8339,15 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-24T16:38:24"
+      "createdAt" : "2023-11-26T19:19:50"
     } ],
     "pageable" : {
       "pageNumber" : 0,
       "pageSize" : 5,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 0,
       "paged" : true,
@@ -8357,15 +8357,15 @@ Content-Length: 1142
     "number" : 0,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
+    "numberOfElements" : 2,
     "first" : true,
     "last" : false,
-    "numberOfElements" : 2,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -8733,7 +8733,7 @@ Content-Length: 1299
       "isBookmarked" : false
     } ]
   },
-  "serverDateTime" : "2023-11-24T16:38:23"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -9016,22 +9016,22 @@ Content-Length: 1245
   "status" : 200,
   "data" : {
     "content" : [ {
-      "id" : "52592e82-1ee0-40fd-8252-c4067d412e28",
+      "id" : "7c1e40bd-0643-4b44-8977-ad0f1f3496ab",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-21T12:00:00"
     }, {
-      "id" : "42712901-02ba-411c-b876-4285f771b10e",
+      "id" : "ce4fc8f8-01b2-4835-a392-320a4bce58cb",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-21T10:00:00"
     }, {
-      "id" : "930faf78-a705-46c5-981b-032bcd4b02fc",
+      "id" : "f7b6b676-1e2f-45a6-9c70-768880fdc5e2",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-20T12:00:00"
     }, {
-      "id" : "0c0df485-3a3c-4f64-a7d0-02bec166eddc",
+      "id" : "eb7efad7-a05f-479d-8e64-f3031756d9b5",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-14T12:00:00"
@@ -9041,8 +9041,8 @@ Content-Length: 1245
       "pageSize" : 4,
       "sort" : {
         "empty" : true,
-        "unsorted" : true,
-        "sorted" : false
+        "sorted" : false,
+        "unsorted" : true
       },
       "offset" : 4,
       "paged" : true,
@@ -9052,15 +9052,15 @@ Content-Length: 1245
     "number" : 1,
     "sort" : {
       "empty" : true,
-      "unsorted" : true,
-      "sorted" : false
+      "sorted" : false,
+      "unsorted" : true
     },
+    "numberOfElements" : 4,
     "first" : false,
     "last" : false,
-    "numberOfElements" : 4,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-24T16:38:22"
+  "serverDateTime" : "2023-11-26T19:19:48"
 }</code></pre>
 </div>
 </div>
@@ -9284,7 +9284,7 @@ Content-Length: 1245
 <h4 id="_http_request_38"><a class="link" href="#_http_request_38">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/alarms/96874ad7-9b0b-4f24-b7f1-8a252fb2883e HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/alarms/97c55ad5-4dc3-4428-afcc-e63be235c0db HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
 Host: localhost:8080</code></pre>
@@ -9339,7 +9339,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-24T16:38:22"
+  "serverDateTime" : "2023-11-26T19:19:48"
 }</code></pre>
 </div>
 </div>
@@ -9402,6 +9402,7 @@ Content-Length: 81
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">POST /api/v1/chat-rooms HTTP/1.1
 Content-Type: application/json;charset=UTF-8
+Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
 Content-Length: 45
 Host: localhost:8080
 
@@ -9465,7 +9466,7 @@ Content-Length: 137
     "missionId" : 1,
     "headCount" : 2
   },
-  "serverDateTime" : "2023-11-24T16:38:23"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -9542,7 +9543,7 @@ Content-Length: 137
 <h4 id="_http_request_40"><a class="link" href="#_http_request_40">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/chat-rooms/users HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">GET /api/v1/chat-rooms/me HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
 Host: localhost:8080</code></pre>
@@ -9573,12 +9574,14 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 720
+Content-Length: 840
 
 {
   "status" : 200,
   "data" : [ {
     "id" : 1,
+    "missionId" : 1,
+    "missionStatus" : "MATCHING",
     "receiverId" : 1,
     "title" : "심부름 해주실 분을 찾습니다.",
     "receiverNickname" : "슈퍼 히어로 토끼 A",
@@ -9588,6 +9591,8 @@ Content-Length: 720
     "lastSentMessageTime" : "2023-11-12T12:00:00"
   }, {
     "id" : 2,
+    "missionId" : 2,
+    "missionStatus" : "MATCHING_COMPLETED",
     "receiverId" : 2,
     "title" : "벌레 잡아주실 분을 찾습니다.",
     "receiverNickname" : "슈퍼 히어로 토끼 B",
@@ -9596,7 +9601,7 @@ Content-Length: 720
     "headCount" : 2,
     "lastSentMessageTime" : "2023-11-12T12:00:00"
   } ],
-  "serverDateTime" : "2023-11-24T16:38:23"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -9643,11 +9648,25 @@ Content-Length: 720
 <td class="tableblock halign-left valign-top"><p class="tableblock">채팅방 아이디</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].missionId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 아이디</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].title</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">미션 제목</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].missionStatus</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">미션 상태</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data[].receiverId</code></p></td>
@@ -9770,7 +9789,7 @@ Content-Length: 134
     "userId" : 1,
     "missionId" : 1
   },
-  "serverDateTime" : "2023-11-24T16:38:23"
+  "serverDateTime" : "2023-11-26T19:19:49"
 }</code></pre>
 </div>
 </div>
@@ -9890,7 +9909,7 @@ Content-Length: 472
       } ]
     } ]
   } ],
-  "serverDateTime" : "2023-11-24T16:38:24"
+  "serverDateTime" : "2023-11-26T19:19:50"
 }</code></pre>
 </div>
 </div>
@@ -9981,7 +10000,7 @@ Content-Length: 472
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-11-24 16:35:49 +0900
+Last updated 2023-11-24 16:39:31 +0900
 </div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.18.3/highlight.min.js"></script>

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/docs/RestDocsSupport.java
@@ -49,8 +49,7 @@ public abstract class RestDocsSupport {
                 .addMappedInterceptors(new String[]{
                         "/api/v1/alarms/**",
                         "/api/v1/sse/**",
-                        "/api/v1/chat-rooms/users",
-                        "/api/v1/chat-rooms/*/exit",
+                        "/api/v1/chat-rooms/**",
                         "/api/v1/mission-proposals/**",
                         "/api/v1/mission-matches/**",
                         "/api/v1/bookmarks",

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/chatroom/response/MissionChatRoomFindResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/chatroom/response/MissionChatRoomFindResponse.java
@@ -11,6 +11,10 @@ import java.time.LocalDateTime;
 public record MissionChatRoomFindResponse(
         Long id,
 
+        Long missionId,
+
+        String missionStatus,
+
         Long receiverId,
 
         String title,
@@ -33,6 +37,8 @@ public record MissionChatRoomFindResponse(
     ) {
         return MissionChatRoomFindResponse.builder()
                 .id(queryResponse.chatRoomId())
+                .missionId(queryResponse.missionId())
+                .missionStatus(queryResponse.missionStatus().name())
                 .receiverId(queryResponse.receiverId())
                 .title(queryResponse.title())
                 .receiverNickname(queryResponse.nickName())

--- a/onedayhero-chat/src/main/java/com/sixheroes/onedayherochat/application/ChatService.java
+++ b/onedayhero-chat/src/main/java/com/sixheroes/onedayherochat/application/ChatService.java
@@ -49,8 +49,9 @@ public class ChatService {
     public List<ChatMessageApiResponse> findMessageByChatRoomId(
             Long chatRoomId
     ) {
-        redisRepository.enterChatRoom(chatRoomId);
         var chatRoomsMessages = chatMessageRepository.findAllByChatRoomId(chatRoomId);
+
+        redisRepository.enterChatRoom(chatRoomId);
 
         return chatRoomsMessages.stream()
                 .map(ChatMessageApiResponse::from)

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/repository/UserMissionChatRoomRepository.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/repository/UserMissionChatRoomRepository.java
@@ -16,7 +16,7 @@ public interface UserMissionChatRoomRepository extends JpaRepository<UserMission
 
     @Query("""
             SELECT NEW com.sixheroes.onedayherodomain.missionchatroom.repository.response.UserChatRoomQueryResponse(
-            mr.id, u.id, m.id, m.missionInfo.title, u.userBasicInfo.nickname, ui.path, mr.headCount
+            mr.id, u.id, m.id, m.missionStatus, m.missionInfo.title, u.userBasicInfo.nickname, ui.path, mr.headCount
             )
             from UserMissionChatRoom um
             join MissionChatRoom mr

--- a/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/repository/response/UserChatRoomQueryResponse.java
+++ b/onedayhero-domain/src/main/java/com/sixheroes/onedayherodomain/missionchatroom/repository/response/UserChatRoomQueryResponse.java
@@ -1,9 +1,12 @@
 package com.sixheroes.onedayherodomain.missionchatroom.repository.response;
 
+import com.sixheroes.onedayherodomain.mission.MissionStatus;
+
 public record UserChatRoomQueryResponse(
         Long chatRoomId,
         Long receiverId,
         Long missionId,
+        MissionStatus missionStatus,
         String title,
         String nickName,
         String path,


### PR DESCRIPTION
## 🖊️ 1. Changes
- 회원이 현재 참가중인 채팅방을 조회 할 때 미션에 대한 아이디와 현재 미션의 진행 정보를 같이 보내달라는 요청이 있었습니다.
이에 따라, 채팅방 조회 시 필요한 프론트 요청 데이터가 추가되었습니다. 
- 기존 ChatController에서 해당 채팅방에 있는 채팅 메시지들을 가져오는 로직은 ChatRoomController로 이전하였습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

-

## ✅ 5. Plans

## 🙌 6. Checklist
- [X] - 통합 테스트를 수행해보셨나요?
- [X] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [X] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
