### PR TITLE
[SIX-257] feat : AccessToken Blacklist 관리 기능 구현

### DIFF
--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/auth/AuthController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/auth/AuthController.java
@@ -1,6 +1,8 @@
 package com.sixheroes.onedayheroapi.auth;
 
 import com.sixheroes.onedayheroapi.auth.response.oauth.LoginRequest;
+import com.sixheroes.onedayheroapi.global.argumentsresolver.authuser.AuthUser;
+import com.sixheroes.onedayheroapplication.auth.BlacklistService;
 import com.sixheroes.onedayheroapplication.auth.TokenService;
 import com.sixheroes.onedayheroapplication.auth.reponse.ReissueTokenResponse;
 import com.sixheroes.onedayheroapplication.oauth.OauthProperties;
@@ -12,6 +14,8 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,6 +32,7 @@ public class AuthController {
     private final OauthProperties oauthProperties;
     private final OauthLoginFacadeService oauthLoginFacadeService;
     private final TokenService tokenService;
+    private final BlacklistService blacklistService;
 
     @PostMapping("/kakao/login")
     public ResponseEntity<ApiResponse<LoginResponse>> loginKakao(
@@ -41,6 +46,18 @@ public class AuthController {
         setCookie(response, loginResponse.refreshToken());
 
         return loginOrSignUpResponse(loginResponse);
+    }
+
+    @PostMapping("/logout")
+    public ResponseEntity<ApiResponse<Void>> logout(
+            @AuthUser Long userId,
+            @CookieValue(value = REFRESH_TOKEN) String refreshToken,
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String header
+    ) {
+        tokenService.deleteRefreshToken(refreshToken);
+        blacklistService.addBlacklist(userId, getAccessToken(header));
+
+        return new ResponseEntity<>(ApiResponse.noContent(), HttpStatus.NO_CONTENT);
     }
 
     @GetMapping("/reissue-token")
@@ -89,5 +106,9 @@ public class AuthController {
         cookie.setMaxAge(0);
         cookie.setPath("/");
         response.addCookie(cookie);
+    }
+
+    private String getAccessToken(String header) {
+        return header.split(" ")[1].trim();
     }
 }

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/configuration/AuthConfiguration.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/configuration/AuthConfiguration.java
@@ -39,7 +39,10 @@ public class AuthConfiguration implements WebMvcConfigurer {
     public void addInterceptors(InterceptorRegistry registry) {
         registry.addInterceptor(new JwtAuthInterceptor(jwtProperties, jwtTokenManager))
                 .order(1)
-                .addPathPatterns("/api/v1/**")
-                .excludePathPatterns("/api/v1/auth/**");
+                .addPathPatterns("/api/v1/**", "/api/v1/auth/logout")
+                .excludePathPatterns(
+                        "/api/v1/auth/kakao/login",
+                        "/api/v1/auth/reissue-token"
+                );
     }
 }

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/interceptor/BlacklistCheckInterceptor.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/interceptor/BlacklistCheckInterceptor.java
@@ -1,0 +1,32 @@
+package com.sixheroes.onedayheroapi.global.interceptor;
+
+import com.sixheroes.onedayheroapplication.auth.BlacklistService;
+import com.sixheroes.onedayherocommon.error.ErrorCode;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+@Slf4j
+@RequiredArgsConstructor
+public class BlacklistCheckInterceptor implements HandlerInterceptor {
+
+    private final BlacklistService blacklistService;
+
+    @Override
+    public boolean preHandle(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            Object handler
+    ) {
+        var accessToken = request.getAttribute("accessToken").toString();
+
+        if (blacklistService.check(accessToken)) {
+            log.warn("탈취된 액세스 토큰으로 접근을 시도했습니다. {}", accessToken);
+            throw new IllegalStateException(ErrorCode.A_001.name());
+        }
+
+        return true;
+    }
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/interceptor/JwtAuthInterceptor.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/interceptor/JwtAuthInterceptor.java
@@ -42,8 +42,10 @@ public class JwtAuthInterceptor implements HandlerInterceptor {
         }
 
         try {
-            var id = jwtTokenManager.getId(getAccessToken(authorizationHeader));
+            var accessToken = getAccessToken(authorizationHeader);
+            var id = jwtTokenManager.getId(accessToken);
             request.setAttribute(jwtProperties.getClaimId(), id);
+            request.setAttribute("accessToken", accessToken);
 
             return true;
         } catch (ExpiredJwtException exception) {

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/auth/AuthControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/auth/AuthControllerTest.java
@@ -3,6 +3,7 @@ package com.sixheroes.onedayheroapi.auth;
 import com.sixheroes.onedayheroapi.auth.response.oauth.LoginRequest;
 import com.sixheroes.onedayheroapi.docs.OauthTestConfiguration;
 import com.sixheroes.onedayheroapi.docs.RestDocsSupport;
+import com.sixheroes.onedayheroapplication.auth.BlacklistService;
 import com.sixheroes.onedayheroapplication.auth.TokenService;
 import com.sixheroes.onedayheroapplication.auth.RefreshTokenGenerator;
 import com.sixheroes.onedayheroapplication.oauth.OauthLoginFacadeService;
@@ -43,9 +44,12 @@ class AuthControllerTest extends RestDocsSupport {
     @MockBean
     private TokenService authService;
 
+    @MockBean
+    private BlacklistService blacklistService;
+
     @Override
     protected Object setController() {
-        return new AuthController(oauthProperties, oauthLoginFacadeService, authService);
+        return new AuthController(oauthProperties, oauthLoginFacadeService, authService, blacklistService);
     }
 
     @DisplayName("카카오 로그인 테스트")

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/jwt/JwtTokenManagerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/jwt/JwtTokenManagerTest.java
@@ -8,6 +8,8 @@ import org.assertj.core.api.SoftAssertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.util.Date;
+
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -16,6 +18,7 @@ class JwtTokenManagerTest {
     private final static String INVALID_FORMAT_ACCESS_TOKEN = "esJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5ODkxMTkyNCwiZXwIjoxNjk4OTEyNTI0fQ.k-sTH0U_HM3lv7augTF2Gx0497DKzDZiyRMzv_QZObQ";
     private final static String TEST_SECRET_KEY = "testtesttesttesttesttesttesttesttesttesttesttesttesttest";
     private final static Long TEST_EXPIRY_TIME_MS = 60000000000L;
+    private final static Long TEST_EXPIRY_TIME_MS2 = 60000L;
     private final static Long TEST_SHORT_EXPIRY_TIME_MS = 1L;
 
     @DisplayName("생성된 액세스토큰 PAYLOAD 에 유저 아이디, 유저 권한이 존재한다.")
@@ -69,6 +72,26 @@ class JwtTokenManagerTest {
         assertThatThrownBy(() ->
                 jwtTokenManager.getId(expiredAccessToken)
         ).isInstanceOf(ExpiredJwtException.class);
+    }
+
+    @DisplayName("액세스 토큰이 만료까지 남은 시간을 계산할 수 있다.")
+    @Test
+    void calculateTokenExpiredTimeMs() {
+        // given
+        var userId = 1L;
+        var userRole = "MEMBER";
+
+        var jwtTokenManager = new JwtTokenManager(createProperties(TEST_EXPIRY_TIME_MS2));
+        var accessToken = jwtTokenManager.generateAccessToken(
+                userId,
+                userRole
+        );
+
+        // when
+        var remainExpiryTimeMs = jwtTokenManager.calculateRemainExpiryTimeMs(accessToken);
+
+        // then
+        assertThat(remainExpiryTimeMs).isGreaterThan(0L);
     }
 
     private JwtProperties createProperties(Long accessTokenExpiryTime) {

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/BlacklistService.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/BlacklistService.java
@@ -1,0 +1,27 @@
+package com.sixheroes.onedayheroapplication.auth;
+
+
+import com.sixheroes.onedayheroapplication.auth.infra.repository.BlacklistRepository;
+import com.sixheroes.onedayheroapplication.global.jwt.JwtTokenManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.time.Duration;
+
+@RequiredArgsConstructor
+@Service
+public class BlacklistService {
+
+    private final BlacklistRepository blacklistRepository;
+    private final JwtTokenManager jwtTokenManager;
+
+    public void addBlacklist(
+            Long userId,
+            String accessToken
+    ) {
+        var remainExpiryTimeMs = jwtTokenManager.calculateRemainExpiryTimeMs(accessToken);
+        var duration = Duration.ofMillis(remainExpiryTimeMs);
+
+        blacklistRepository.save(accessToken, String.valueOf(userId), duration);
+    }
+}

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/BlacklistService.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/BlacklistService.java
@@ -15,6 +15,12 @@ public class BlacklistService {
     private final BlacklistRepository blacklistRepository;
     private final JwtTokenManager jwtTokenManager;
 
+    public Boolean check(
+            String accessToken
+    ) {
+        return blacklistRepository.exist(accessToken);
+    }
+
     public void addBlacklist(
             Long userId,
             String accessToken

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/TokenService.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/TokenService.java
@@ -1,6 +1,7 @@
 package com.sixheroes.onedayheroapplication.auth;
 
 
+import com.sixheroes.onedayheroapplication.auth.infra.repository.BlacklistRepository;
 import com.sixheroes.onedayheroapplication.auth.infra.repository.RefreshTokenRepository;
 import com.sixheroes.onedayheroapplication.auth.reponse.ReissueTokenResponse;
 import com.sixheroes.onedayheroapplication.global.jwt.JwtProperties;
@@ -23,6 +24,7 @@ public class TokenService {
     private final JwtProperties jwtProperties;
     private final JwtTokenManager jwtTokenManager;
     private final RefreshTokenRepository refreshTokenRepository;
+    private final BlacklistRepository blacklistRepository;
 
     public String generateRefreshToken(
             Long userId
@@ -38,6 +40,12 @@ public class TokenService {
         );
 
         return refreshToken;
+    }
+
+    public void deleteRefreshToken(
+            String refreshToken
+    ) {
+        refreshTokenRepository.delete(refreshToken);
     }
 
     public Optional<RefreshToken> findRefreshTokenValue(

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/infra/redis/RedisConfiguration.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/infra/redis/RedisConfiguration.java
@@ -11,8 +11,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @Configuration
 public class RedisConfiguration {
 
-    @Bean(name = "refreshTokenRedisTemplate")
-    public RedisTemplate<String, String> refreshTokenRedisTemplate(
+    @Bean(name = "authRedisTemplate")
+    public RedisTemplate<String, String> authRedisTemplate(
             RedisConnectionFactory redisConnectionFactory
     ) {
         RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/infra/repository/BlacklistRepository.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/infra/repository/BlacklistRepository.java
@@ -18,6 +18,12 @@ public class BlacklistRepository {
         this.redisTemplate = redisTemplate;
     }
 
+    public Boolean exist(
+            String key
+    ) {
+        return redisTemplate.opsForValue().get(key) != null;
+    }
+
     public void save(
             String key,
             String value,

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/infra/repository/BlacklistRepository.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/infra/repository/BlacklistRepository.java
@@ -1,0 +1,28 @@
+package com.sixheroes.onedayheroapplication.auth.infra.repository;
+
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import java.time.Duration;
+
+@Repository
+public class BlacklistRepository {
+
+    private final RedisTemplate<String, String> redisTemplate;
+
+    public BlacklistRepository(
+            @Qualifier("authRedisTemplate") RedisTemplate<String, String> redisTemplate
+    ) {
+        this.redisTemplate = redisTemplate;
+    }
+
+    public void save(
+            String key,
+            String value,
+            Duration duration
+    ) {
+        redisTemplate.opsForValue().set(key, value, duration);
+    }
+}

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/infra/repository/RefreshTokenRepository.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/auth/infra/repository/RefreshTokenRepository.java
@@ -16,7 +16,7 @@ public class RefreshTokenRepository {
     private final RedisTemplate<String, String> redisTemplate;
 
     public RefreshTokenRepository(
-            @Qualifier("refreshTokenRedisTemplate") RedisTemplate<String, String> redisTemplate
+            @Qualifier("authRedisTemplate") RedisTemplate<String, String> redisTemplate
     ) {
         this.redisTemplate = redisTemplate;
     }

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/global/jwt/JwtTokenManager.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/global/jwt/JwtTokenManager.java
@@ -34,6 +34,19 @@ public class JwtTokenManager {
         );
     }
 
+    public Long calculateRemainExpiryTimeMs(
+            String token
+    ) {
+        try {
+            var currentTimeMs = new Date().getTime();
+            var expirationDate = extractClaims(token).getExpiration();
+
+            return expirationDate.getTime() - currentTimeMs;
+        } catch (JwtException jwtException) {
+            return 0L;
+        }
+    }
+
     private Claims extractClaims(
             String token
     ) throws JwtException {


### PR DESCRIPTION
## 🖊️ 1. Changes
- 로그아웃(블랙리스트 적용) 기능 추가
- 사용자의 요청이 들어오면 블랙리스트에 등록된 액세스 토큰인지 확인하는 `BlacklistCheckInterceptor` 인터셉터 추가
- 블랙리스트를 관리하는 레디스 기반의 저장소인 `BlacklistRepository` 추가 및 저장소 접근 서비스 코드 구현

## 🖼️ 2. Screenshot

## ❗️ 3. Issues

## 😌 4. To Reviewer

### 로그아웃~블랙리스트 검사 동작 순서
1.  사용자는 쿠키와 헤더에 RT 와 AT 을 담아 로그아웃을 요청
2. 서버는 RT 만료시킴
3. 서버는 AT 의 남은 만료 시간만큼 유지되는 블랙리스트에 AT 을 등록
4. AT(블랙리스트에 유지되고 있는) 을 탈취한 공격자가 AT 을 헤더에 넣어 서버에 요청
5. `BlacklistCheckInterceptor` 인터셉터에서 헤더를 읽어 블랙리스트에 등록된 AT 인지 검사
6. 블랙리스트에 존재하는 AT 이므로 사용자에게 인가에 실패했다는 응답을 전송

## ✅ 5. Plans

## 🙌 6. Checklist
- [x] - 통합 테스트를 수행해보셨나요?
- [x] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [x] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
