### PR TITLE
[SIX-262] MDC 및 AOP를 이용한 Log Trace 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ subprojects {
 
     dependencies {
         implementation 'org.springframework.boot:spring-boot-starter'
+        implementation 'org.springframework.boot:spring-boot-starter-aop'
         compileOnly 'org.projectlombok:lombok'
         annotationProcessor 'org.projectlombok:lombok'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/aspect/LogAspect.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/aspect/LogAspect.java
@@ -46,7 +46,7 @@ public class LogAspect {
         var methodName = joinPoint.getSignature().toShortString();
         Object result = joinPoint.proceed();
         var executeTime = System.currentTimeMillis() - beforeTime;
-        log.warn("[{}] methodName : [{}] time = [{}ms]", MDC.get(TRACE_ID_NAME), methodName, executeTime);
+        log.debug("[{}] methodName : [{}] time = [{}ms]", MDC.get(TRACE_ID_NAME), methodName, executeTime);
         return result;
     }
 

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/aspect/LogAspect.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/aspect/LogAspect.java
@@ -1,0 +1,53 @@
+package com.sixheroes.onedayheroapi.global.aspect;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.AfterThrowing;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Aspect
+@Component
+public class LogAspect {
+
+    private static final String TRACE_ID_NAME = "request_id";
+
+    @Pointcut("bean(*Service)")
+    private void service() {
+    }
+
+    @Pointcut("bean(*Controller)")
+    private void controller() {
+    }
+
+    @AfterThrowing(pointcut = "service()", throwing = "exception")
+    private void logException(
+            JoinPoint joinPoint,
+            RuntimeException exception
+    ) {
+        String exceptionName = exception.getClass().getSimpleName();
+        String exceptionMessage = exception.getMessage();
+        String methodName = joinPoint.getSignature().toShortString();
+        Object[] args = joinPoint.getArgs();
+        log.warn("[{}] [Exception] {} , exceptionName = {}, exceptionMessage = {}, args = {}",
+                MDC.get(TRACE_ID_NAME), methodName, exceptionName, exceptionMessage, args);
+    }
+
+    @Around("controller()")
+    private Object log(
+            ProceedingJoinPoint joinPoint
+    ) throws Throwable {
+        var beforeTime = System.currentTimeMillis();
+        var methodName = joinPoint.getSignature().toShortString();
+        Object result = joinPoint.proceed();
+        var executeTime = System.currentTimeMillis() - beforeTime;
+        log.warn("[{}] methodName : [{}] time = [{}ms]", MDC.get(TRACE_ID_NAME), methodName, executeTime);
+        return result;
+    }
+
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/filter/MDCLoggingFilter.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/filter/MDCLoggingFilter.java
@@ -1,0 +1,23 @@
+package com.sixheroes.onedayheroapi.global.filter;
+
+import jakarta.servlet.*;
+import jakarta.servlet.http.HttpServletRequest;
+import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Component
+public class MDCLoggingFilter implements Filter {
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+        var requestId = ((HttpServletRequest) request).getHeader("X-RequestID");
+
+        var traceId = requestId != null ? requestId : UUID.randomUUID().toString().replaceAll("-", "");
+        MDC.put("request_id", traceId);
+        chain.doFilter(request, response);
+        MDC.clear();
+    }
+}

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/interceptor/BlacklistCheckInterceptor.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/global/interceptor/BlacklistCheckInterceptor.java
@@ -2,6 +2,7 @@ package com.sixheroes.onedayheroapi.global.interceptor;
 
 import com.sixheroes.onedayheroapplication.auth.BlacklistService;
 import com.sixheroes.onedayherocommon.error.ErrorCode;
+import com.sixheroes.onedayherocommon.exception.auth.InvalidAuthorizationException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -24,7 +25,7 @@ public class BlacklistCheckInterceptor implements HandlerInterceptor {
 
         if (blacklistService.check(accessToken)) {
             log.warn("탈취된 액세스 토큰으로 접근을 시도했습니다. {}", accessToken);
-            throw new IllegalStateException(ErrorCode.A_001.name());
+            throw new InvalidAuthorizationException(ErrorCode.UNAUTHORIZED_TOKEN_REQUEST);
         }
 
         return true;

--- a/onedayhero-api/src/main/resources/logback-spring.xml
+++ b/onedayhero-api/src/main/resources/logback-spring.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- 로그 패턴에 색상 적용 %clr(pattern){color} -->
+    <conversionRule conversionWord="clr" converterClass="org.springframework.boot.logging.logback.ColorConverter"/>
+
+    <!-- log 변수 값 설정 -->
+    <property name="CONSOLE_LOG_PATTERN"
+              value="[%d{yyyy-MM-dd HH:mm:ss}:%-3relative] %clr(%-5level) %clr(${PID:-}){magenta} [%X{request_id:-startup}] %clr(---){faint} %clr([%15.15thread]){faint} %clr(%-40.40logger{36}){cyan} %clr(:){faint} %msg%n"/>
+
+    <!-- 콘솔(STDOUT) -->
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>${CONSOLE_LOG_PATTERN}</Pattern>
+        </layout>
+    </appender>
+    
+    <root level="INFO">
+        <appender-ref ref="STDOUT"/>
+    </root>
+</configuration>

--- a/onedayhero-chat/build.gradle
+++ b/onedayhero-chat/build.gradle
@@ -8,7 +8,6 @@ dependencies {
     // test Container
     testImplementation 'org.testcontainers:testcontainers:1.19.1'
 
-
     // Project
     implementation project(':onedayhero-domain')
     implementation project(':onedayhero-common')


### PR DESCRIPTION
## 🖊️ 1. Changes
- MDC를 적용하여 로그 추적이 용이하도록 수정하였습니다.
- controller 진입 후부터 종료 때까지의 실행 시간을 추적하기 위한 aop
- Service 진입 후 발생하는 예외에 대해서 추적하는 aop를 추가하였습니다.  

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

- MDC(Mapped Diagnostic Context)를 직접 만들어주려고 시도하다가 보니, 라이브러리에서 제공해주는 MDC가 있는 것을 확인 할 수 있었습니다. 
- jboss mdc 와 slf4j mdc 두 가지가 있었는데, Springboot에서는 임포트 때 springboot-starter-logging이 추가되고 slf4j가 인터페이스격으로 사용되니 해당 라이브러리를 쓰는게 더 좋지 않을까란 판단에 slf4j의 MDC 클래스를 사용하였습니다.

## ✅ 5. Plans
- [x] - Grafana로 warn, error에 대한 로깅 알람 추가
- [ ] - 

## 🙌 6. Checklist
- [X] - 통합 테스트를 수행해보셨나요?
- [X] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [X] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
