### PR TITLE
[SIX-211] 유저 프로필 수정 API 로직 변경 & SSE 이벤트가 아닌 메시지로 전달

### DIFF
--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseController.java
@@ -7,12 +7,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
-
-import java.io.IOException;
 
 @RequiredArgsConstructor
 @Slf4j
@@ -20,7 +17,6 @@ import java.io.IOException;
 @RestController
 public class SseController {
 
-    private static final String DUMMY_DATA_NAME = "success";
     private static final String DUMMY_DATA = "Sse subscribe success";
     private final SseEmitters sseEmitters;
 
@@ -30,27 +26,14 @@ public class SseController {
         @AuthUser Long userId
     ) {
         var sseEmitter = sseEmitters.add(userId);
-        try {
-            sseEmitter.send("sse emitter 응답 보내기");
-            log.info("sse emitter controller에서 응답 보내영");
-        } catch (IOException e) {
-            log.error("보내는데 오류났어요!");
-            throw new RuntimeException(e);
-        }
+
         response.setHeader(HttpHeaders.CONNECTION, "keep-alive");
         response.setHeader(HttpHeaders.CONTENT_TYPE, "text/event-stream;charset=utf-8");
         response.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache, no-transform");
         response.setHeader("X-Accel-Buffering", "no");
-        sseEmitters.send(userId, DUMMY_DATA_NAME, DUMMY_DATA);
-        return sseEmitter;
-    }
 
-    @GetMapping("/send/{receiverId}")
-    public void send(
-        @AuthUser Long userId,
-        @PathVariable Long receiverId
-    ) throws IOException {
-        var sseEmitter = sseEmitters.get(receiverId);
-        sseEmitter.send("알림이에영~~~");
+        sseEmitters.send(userId, DUMMY_DATA);
+
+        return sseEmitter;
     }
 }

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEmitters.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEmitters.java
@@ -5,7 +5,6 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import java.io.IOException;
-import java.time.LocalDateTime;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -33,16 +32,11 @@ public class SseEmitters {
 
     public void send(
         Long userId,
-        String name,
         Object data
     ) {
         var sseEmitter = get(userId);
         try {
-            sseEmitter.send(SseEmitter.event()
-                .id(LocalDateTime.now().toString())
-                .name(name)
-                .data(data)
-            );
+            sseEmitter.send(data);
             log.info("sse emiiter를 보내는데 성공했습니다.");
         } catch (IOException e) {
             log.error("SSE를 보내는 과정에서 오류가 발생했습니다.");
@@ -55,7 +49,7 @@ public class SseEmitters {
     ) {
         var sseEmitter = emitters.get(userId);
         if (sseEmitter == null) {
-            log.debug("SSE를 구독하지 않은 유저입니다. userId : {}", userId);
+            log.warn("SSE를 구독하지 않은 유저입니다. userId : {}", userId);
         }
         return sseEmitter;
     }

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEventListener.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/sse/SseEventListener.java
@@ -16,7 +16,6 @@ public class SseEventListener {
     public void sendSseEmitter(SsePayload ssePaylod) {
         sseEmitters.send(
             ssePaylod.userId(),
-            "alarm",
             ssePaylod.data()
         );
     }

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/user/UserController.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/user/UserController.java
@@ -17,7 +17,6 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.web.PageableDefault;
-import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -113,15 +112,5 @@ public class UserController {
         var userUpdateResponse = userService.turnOffHeroMode(userId);
 
         return ResponseEntity.ok(ApiResponse.ok(userUpdateResponse));
-    }
-
-    @DeleteMapping("/user-images/{userImageId}")
-    public ResponseEntity<ApiResponse<Void>> deleteUserImage(
-        @AuthUser Long userId,
-        @PathVariable Long userImageId
-    ) {
-        userService.deleteUserImage(userId, userImageId);
-
-        return new ResponseEntity<>(ApiResponse.noContent(), HttpStatus.NO_CONTENT);
     }
 }

--- a/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/user/request/UserUpdateRequest.java
+++ b/onedayhero-api/src/main/java/com/sixheroes/onedayheroapi/user/request/UserUpdateRequest.java
@@ -12,6 +12,8 @@ public record UserUpdateRequest(
         @Valid
         UserBasicInfoRequest basicInfo,
 
+        Long userImageId,
+
         @Valid
         UserFavoriteWorkingDayRequest favoriteWorkingDay,
 
@@ -34,9 +36,10 @@ public record UserUpdateRequest(
             .build();
 
         return UserServiceUpdateRequest.builder()
-                .userBasicInfo(userBasicInfoServiceDto)
-                .userFavoriteWorkingDay(userFavoriteWorkingDayServiceDto)
-                .userFavoriteRegions(favoriteRegions)
-                .build();
+            .userBasicInfo(userBasicInfoServiceDto)
+            .userImageId(userImageId)
+            .userFavoriteWorkingDay(userFavoriteWorkingDayServiceDto)
+            .userFavoriteRegions(favoriteRegions)
+            .build();
     }
 }

--- a/onedayhero-api/src/main/resources/static/docs/index.html
+++ b/onedayhero-api/src/main/resources/static/docs/index.html
@@ -604,7 +604,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Set-Cookie: refreshToken=18d589bc-13db-4eab-9288-f3210586a873; HttpOnly
+Set-Cookie: refreshToken=07e74d87-9800-432b-b346-cb530ff22105; HttpOnly
 Location:
 Content-Type: application/json;charset=UTF-8
 Content-Length: 134
@@ -615,7 +615,7 @@ Content-Length: 134
     "userId" : 1,
     "accessToken" : "accessToken"
   },
-  "serverDateTime" : "2023-11-28T16:11:21"
+  "serverDateTime" : "2023-11-28T16:39:55"
 }</code></pre>
 </div>
 </div>
@@ -731,7 +731,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: refreshToken=a4c5fd0b-2c74-4ce7-a52e-63f7f719d095; HttpOnly
+Set-Cookie: refreshToken=f97c157f-5193-43cf-a089-737b9636d6f6; HttpOnly
 Content-Type: application/json;charset=UTF-8
 Content-Length: 134
 
@@ -741,7 +741,7 @@ Content-Length: 134
     "userId" : 1,
     "accessToken" : "accessToken"
   },
-  "serverDateTime" : "2023-11-28T16:11:21"
+  "serverDateTime" : "2023-11-28T16:39:55"
 }</code></pre>
 </div>
 </div>
@@ -847,7 +847,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 781
+Content-Length: 797
 
 {
   "status" : 200,
@@ -859,6 +859,7 @@ Content-Length: 781
       "introduce" : "자기 소개"
     },
     "image" : {
+      "id" : 1,
       "originalName" : "profile.jpg",
       "uniqueName" : "unique.jpg",
       "path" : "http://"
@@ -882,7 +883,7 @@ Content-Length: 781
     "heroScore" : 30,
     "isHeroMode" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:24"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -969,6 +970,13 @@ Content-Length: 781
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.image.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.image.originalName</code></p></td>
@@ -1200,7 +1208,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:24"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -1520,7 +1528,7 @@ Content-Length: 2193
       "empty" : false
     }
   },
-  "serverDateTime" : "2023-11-28T16:11:24"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -1898,7 +1906,7 @@ Content-Length: 1130
       "starScore" : 3,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-28T16:11:24"
+      "createdAt" : "2023-11-28T16:39:57"
     }, {
       "reviewId" : 2,
       "categoryName" : "청소",
@@ -1906,7 +1914,7 @@ Content-Length: 1130
       "starScore" : 4,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-28T16:11:24"
+      "createdAt" : "2023-11-28T16:39:57"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -1932,7 +1940,7 @@ Content-Length: 1130
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:24"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -2248,7 +2256,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-28T16:11:24"
+      "createdAt" : "2023-11-28T16:39:57"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -2257,7 +2265,7 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-28T16:11:24"
+      "createdAt" : "2023-11-28T16:39:57"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -2283,7 +2291,7 @@ Content-Length: 1142
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:24"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -2573,7 +2581,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:24"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -2674,7 +2682,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:24"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -2773,7 +2781,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 335
+Content-Length: 351
 
 {
   "status" : 200,
@@ -2784,13 +2792,14 @@ Content-Length: 335
       "birth" : "1990-01-01"
     },
     "image" : {
+      "id" : 1,
       "originalName" : "profile.jpg",
       "uniqueName" : "unique.jpg",
       "path" : "https://"
     },
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:48"
 }</code></pre>
 </div>
 </div>
@@ -2872,6 +2881,13 @@ Content-Length: 335
 <td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.image.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">O</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 아이디</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.image.originalName</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">O</p></td>
@@ -2940,7 +2956,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 756
+Content-Length: 772
 
 {
   "status" : 200,
@@ -2952,6 +2968,7 @@ Content-Length: 756
       "introduce" : "자기 소개"
     },
     "image" : {
+      "id" : 1,
       "originalName" : "profile.jpg",
       "uniqueName" : "unique.jpg",
       "path" : "https://"
@@ -2974,7 +2991,7 @@ Content-Length: 756
     } ],
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:48"
 }</code></pre>
 </div>
 </div>
@@ -3061,6 +3078,13 @@ Content-Length: 756
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">프로필 이미지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.image.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">O</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.image.originalName</code></p></td>
@@ -3202,7 +3226,7 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
 Content-Type: application/json;charset=UTF-8
-Content-Length: 1432
+Content-Length: 1486
 
 {
   "status" : 200,
@@ -3211,6 +3235,7 @@ Content-Length: 1432
       "id" : 2,
       "nickname" : "달님",
       "image" : {
+        "id" : 1,
         "originalName" : "profile.jpg",
         "uniqueName" : "unique.jpg",
         "path" : "https://"
@@ -3224,6 +3249,7 @@ Content-Length: 1432
       "id" : 3,
       "nickname" : "별님",
       "image" : {
+        "id" : 1,
         "originalName" : "profile.jpg",
         "uniqueName" : "unique.jpg",
         "path" : "https://"
@@ -3237,6 +3263,7 @@ Content-Length: 1432
       "id" : 1,
       "nickname" : "햇님",
       "image" : {
+        "id" : 1,
         "originalName" : "profile.jpg",
         "uniqueName" : "unique.jpg",
         "path" : "https://"
@@ -3268,7 +3295,7 @@ Content-Length: 1432
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:48"
 }</code></pre>
 </div>
 </div>
@@ -3334,6 +3361,13 @@ Content-Length: 1432
 <td class="tableblock halign-left valign-top"><p class="tableblock">O</p></td>
 <td class="tableblock halign-left valign-top"></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">이미지 원본 이름</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].image.id</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">O</p></td>
+<td class="tableblock halign-left valign-top"></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">이미지 아이디</p></td>
 </tr>
 <tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.content[].image.uniqueName</code></p></td>
@@ -3665,7 +3699,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -3812,7 +3846,7 @@ Content-Length: 755
     "paths" : [ "path://1", "path://2" ],
     "isBookmarked" : true
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -4200,7 +4234,7 @@ Content-Length: 2029
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -4664,7 +4698,7 @@ Content-Length: 874
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -5011,7 +5045,7 @@ Content-Length: 874
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -5368,7 +5402,7 @@ Content-Length: 1276
       "isBookmarked" : true
     } ]
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -5716,7 +5750,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -5892,7 +5926,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -6030,7 +6064,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -6169,7 +6203,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -6362,7 +6396,7 @@ Content-Length: 1666
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -6762,7 +6796,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -6896,7 +6930,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -7040,7 +7074,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -7176,7 +7210,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -7326,7 +7360,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -7445,7 +7479,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -7545,7 +7579,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -7678,7 +7712,7 @@ Content-Length: 4034
         "status" : "MATCHING",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-28T16:11:23",
+        "createdAt" : "2023-11-28T16:39:56",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7705,7 +7739,7 @@ Content-Length: 4034
         "status" : "MATCHING",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-27T16:11:23",
+        "createdAt" : "2023-11-27T16:39:56",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7732,7 +7766,7 @@ Content-Length: 4034
         "status" : "MATCHING_COMPLETED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-25T16:11:23",
+        "createdAt" : "2023-11-25T16:39:56",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7759,7 +7793,7 @@ Content-Length: 4034
         "status" : "MISSION_COMPLETED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-26T16:11:23",
+        "createdAt" : "2023-11-26T16:39:56",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7786,7 +7820,7 @@ Content-Length: 4034
         "status" : "EXPIRED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-25T16:11:23",
+        "createdAt" : "2023-11-25T16:39:56",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7830,7 +7864,7 @@ Content-Length: 4034
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:56"
 }</code></pre>
 </div>
 </div>
@@ -8275,7 +8309,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -8397,7 +8431,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -8518,9 +8552,9 @@ Content-Length: 719
       "uniqueName" : "B",
       "path" : "S3 이미지 주소B"
     } ],
-    "createdAt" : "2023-11-28T16:11:23"
+    "createdAt" : "2023-11-28T16:39:57"
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -8724,7 +8758,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -8808,7 +8842,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-28T16:11:23"
+      "createdAt" : "2023-11-28T16:39:57"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -8817,7 +8851,7 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-28T16:11:23"
+      "createdAt" : "2023-11-28T16:39:57"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -8843,7 +8877,7 @@ Content-Length: 1142
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>
@@ -9211,7 +9245,7 @@ Content-Length: 1299
       "isBookmarked" : false
     } ]
   },
-  "serverDateTime" : "2023-11-28T16:11:22"
+  "serverDateTime" : "2023-11-28T16:39:55"
 }</code></pre>
 </div>
 </div>
@@ -9445,10 +9479,7 @@ Host: localhost:8080</code></pre>
 Connection: keep-alive
 Content-Type: text/event-stream;charset=utf-8
 Cache-Control: no-cache, no-transform
-X-Accel-Buffering: no
-Content-Length: 35
-
-data:sse emitter 응답 보내기</code></pre>
+X-Accel-Buffering: no</code></pre>
 </div>
 </div>
 </div>
@@ -9501,22 +9532,22 @@ Content-Length: 1245
   "status" : 200,
   "data" : {
     "content" : [ {
-      "id" : "dc3fea1f-1974-4dc1-a7f4-d06b9af4d1a6",
+      "id" : "1e8bc6cd-ae6b-4461-bcbb-11351d26e7f5",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-21T12:00:00"
     }, {
-      "id" : "8b94c210-ffb8-4136-8310-f745d9606c75",
+      "id" : "976d9d07-7d85-4c8d-9ae2-f5988cbf0d47",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-21T10:00:00"
     }, {
-      "id" : "a06d9051-dfb6-4d03-b4ef-a8f4cd2a9eb0",
+      "id" : "23125d7a-791d-4570-ac2a-8f1ab805c4c2",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-20T12:00:00"
     }, {
-      "id" : "1fa00524-052c-4c66-8f88-b53c54738301",
+      "id" : "2f845eca-9211-438b-9450-55f826fc4959",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-14T12:00:00"
@@ -9545,7 +9576,7 @@ Content-Length: 1245
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:11:21"
+  "serverDateTime" : "2023-11-28T16:39:55"
 }</code></pre>
 </div>
 </div>
@@ -9769,7 +9800,7 @@ Content-Length: 1245
 <h4 id="_http_request_39"><a class="link" href="#_http_request_39">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/alarms/86170619-fcfb-46c9-9f24-33ba4a500299 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/alarms/b05e19aa-2e31-4ef8-8d71-9837c62c2d2b HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
 Host: localhost:8080</code></pre>
@@ -9824,7 +9855,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-28T16:11:21"
+  "serverDateTime" : "2023-11-28T16:39:55"
 }</code></pre>
 </div>
 </div>
@@ -9951,7 +9982,7 @@ Content-Length: 137
     "missionId" : 1,
     "headCount" : 2
   },
-  "serverDateTime" : "2023-11-28T16:11:21"
+  "serverDateTime" : "2023-11-28T16:39:55"
 }</code></pre>
 </div>
 </div>
@@ -10086,7 +10117,7 @@ Content-Length: 840
     "headCount" : 2,
     "lastSentMessageTime" : "2023-11-12T12:00:00"
   } ],
-  "serverDateTime" : "2023-11-28T16:11:21"
+  "serverDateTime" : "2023-11-28T16:39:55"
 }</code></pre>
 </div>
 </div>
@@ -10277,7 +10308,7 @@ Content-Length: 409
     "message" : "안녕하세요! 미션 내용 확인하고자합니다!",
     "sentMessageTime" : "2023-11-26T19:27:00"
   } ],
-  "serverDateTime" : "2023-11-28T16:11:21"
+  "serverDateTime" : "2023-11-28T16:39:55"
 }</code></pre>
 </div>
 </div>
@@ -10423,7 +10454,7 @@ Content-Length: 134
     "userId" : 1,
     "missionId" : 1
   },
-  "serverDateTime" : "2023-11-28T16:11:21"
+  "serverDateTime" : "2023-11-28T16:39:55"
 }</code></pre>
 </div>
 </div>
@@ -10543,7 +10574,7 @@ Content-Length: 472
       } ]
     } ]
   } ],
-  "serverDateTime" : "2023-11-28T16:11:23"
+  "serverDateTime" : "2023-11-28T16:39:57"
 }</code></pre>
 </div>
 </div>

--- a/onedayhero-api/src/main/resources/static/docs/index.html
+++ b/onedayhero-api/src/main/resources/static/docs/index.html
@@ -604,7 +604,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 201 Created
-Set-Cookie: refreshToken=cb7afd33-b838-4a85-b252-ea91df22325d; HttpOnly
+Set-Cookie: refreshToken=18d589bc-13db-4eab-9288-f3210586a873; HttpOnly
 Location:
 Content-Type: application/json;charset=UTF-8
 Content-Length: 134
@@ -615,7 +615,7 @@ Content-Length: 134
     "userId" : 1,
     "accessToken" : "accessToken"
   },
-  "serverDateTime" : "2023-11-28T16:02:25"
+  "serverDateTime" : "2023-11-28T16:11:21"
 }</code></pre>
 </div>
 </div>
@@ -731,7 +731,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">HTTP/1.1 200 OK
-Set-Cookie: refreshToken=8bfce315-c78a-4f7d-9b37-cc5a44727c82; HttpOnly
+Set-Cookie: refreshToken=a4c5fd0b-2c74-4ce7-a52e-63f7f719d095; HttpOnly
 Content-Type: application/json;charset=UTF-8
 Content-Length: 134
 
@@ -741,7 +741,7 @@ Content-Length: 134
     "userId" : 1,
     "accessToken" : "accessToken"
   },
-  "serverDateTime" : "2023-11-28T16:02:25"
+  "serverDateTime" : "2023-11-28T16:11:21"
 }</code></pre>
 </div>
 </div>
@@ -882,7 +882,7 @@ Content-Length: 781
     "heroScore" : 30,
     "isHeroMode" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:24"
 }</code></pre>
 </div>
 </div>
@@ -1088,7 +1088,7 @@ Host: localhost:8080
 Content-Disposition: form-data; name=userUpdateRequest; filename=json
 Content-Type: application/json
 
-{"basicInfo":{"nickname":"이름","gender":"MALE","birth":"1990-01-01","introduce":"자기 소개"},"favoriteWorkingDay":{"favoriteDate":["MON","THU"],"favoriteStartTime":"12:00","favoriteEndTime":"18:00"},"favoriteRegions":[1,2]}
+{"basicInfo":{"nickname":"이름","gender":"MALE","birth":"1990-01-01","introduce":"자기 소개"},"userImageId":1,"favoriteWorkingDay":{"favoriteDate":["MON","THU"],"favoriteStartTime":"12:00","favoriteEndTime":"18:00"},"favoriteRegions":[1,2]}
 --6o2knFse3p53ty9dmcQvWAIx1zInP11uCfbm
 Content-Disposition: form-data; name=images; filename=imageA.jpeg
 Content-Type: image/jpeg
@@ -1155,6 +1155,11 @@ Content-Type: image/jpeg
 <td class="tableblock halign-left valign-top"><p class="tableblock">자기 소개</p></td>
 </tr>
 <tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>userImageId</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">유저의 이미지 아이디</p></td>
+</tr>
+<tr>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>favoriteWorkingDay</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock"><code>Object</code></p></td>
 <td class="tableblock halign-left valign-top"><p class="tableblock">희망 근무 정보</p></td>
@@ -1195,7 +1200,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:24"
 }</code></pre>
 </div>
 </div>
@@ -1515,7 +1520,7 @@ Content-Length: 2193
       "empty" : false
     }
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:24"
 }</code></pre>
 </div>
 </div>
@@ -1893,7 +1898,7 @@ Content-Length: 1130
       "starScore" : 3,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-28T16:02:28"
+      "createdAt" : "2023-11-28T16:11:24"
     }, {
       "reviewId" : 2,
       "categoryName" : "청소",
@@ -1901,7 +1906,7 @@ Content-Length: 1130
       "starScore" : 4,
       "senderNickname" : "리뷰 작성자 닉네임",
       "profileImage" : [ "s3 프로필 이미지 주소" ],
-      "createdAt" : "2023-11-28T16:02:28"
+      "createdAt" : "2023-11-28T16:11:24"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -1927,7 +1932,7 @@ Content-Length: 1130
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:24"
 }</code></pre>
 </div>
 </div>
@@ -2243,7 +2248,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-28T16:02:28"
+      "createdAt" : "2023-11-28T16:11:24"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -2252,7 +2257,7 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-28T16:02:28"
+      "createdAt" : "2023-11-28T16:11:24"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -2278,7 +2283,7 @@ Content-Length: 1142
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:24"
 }</code></pre>
 </div>
 </div>
@@ -2568,7 +2573,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:24"
 }</code></pre>
 </div>
 </div>
@@ -2669,7 +2674,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:24"
 }</code></pre>
 </div>
 </div>
@@ -2785,7 +2790,7 @@ Content-Length: 335
     },
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -2969,7 +2974,7 @@ Content-Length: 756
     } ],
     "heroScore" : 60
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -3263,7 +3268,7 @@ Content-Length: 1432
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:28"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -3660,7 +3665,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -3807,7 +3812,7 @@ Content-Length: 755
     "paths" : [ "path://1", "path://2" ],
     "isBookmarked" : true
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -4195,7 +4200,7 @@ Content-Length: 2029
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -4659,7 +4664,7 @@ Content-Length: 874
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -5006,7 +5011,7 @@ Content-Length: 874
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -5363,7 +5368,7 @@ Content-Length: 1276
       "isBookmarked" : true
     } ]
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -5711,7 +5716,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -5887,7 +5892,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -6025,7 +6030,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -6164,7 +6169,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -6357,7 +6362,7 @@ Content-Length: 1666
     "last" : true,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -6757,7 +6762,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -6891,7 +6896,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -7035,7 +7040,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -7171,7 +7176,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -7321,7 +7326,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -7440,7 +7445,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -7540,7 +7545,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -7673,7 +7678,7 @@ Content-Length: 4034
         "status" : "MATCHING",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-28T16:02:27",
+        "createdAt" : "2023-11-28T16:11:23",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7700,7 +7705,7 @@ Content-Length: 4034
         "status" : "MATCHING",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-27T16:02:27",
+        "createdAt" : "2023-11-27T16:11:23",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7727,7 +7732,7 @@ Content-Length: 4034
         "status" : "MATCHING_COMPLETED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-25T16:02:27",
+        "createdAt" : "2023-11-25T16:11:23",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7754,7 +7759,7 @@ Content-Length: 4034
         "status" : "MISSION_COMPLETED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-26T16:02:27",
+        "createdAt" : "2023-11-26T16:11:23",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7781,7 +7786,7 @@ Content-Length: 4034
         "status" : "EXPIRED",
         "bookmarkCount" : 5,
         "isBookmarked" : true,
-        "createdAt" : "2023-11-25T16:02:27",
+        "createdAt" : "2023-11-25T16:11:23",
         "region" : {
           "si" : "서울시",
           "gu" : "프로구",
@@ -7825,7 +7830,7 @@ Content-Length: 4034
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -8270,7 +8275,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -8392,7 +8397,7 @@ Content-Length: 95
   "data" : {
     "id" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -8513,9 +8518,9 @@ Content-Length: 719
       "uniqueName" : "B",
       "path" : "S3 이미지 주소B"
     } ],
-    "createdAt" : "2023-11-28T16:02:27"
+    "createdAt" : "2023-11-28T16:11:23"
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -8719,7 +8724,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -8803,7 +8808,7 @@ Content-Length: 1142
       "categoryName" : "청소",
       "missionTitle" : "청소 미션",
       "starScore" : 4,
-      "createdAt" : "2023-11-28T16:02:27"
+      "createdAt" : "2023-11-28T16:11:23"
     }, {
       "reviewId" : 2,
       "senderId" : 8,
@@ -8812,7 +8817,7 @@ Content-Length: 1142
       "categoryName" : "심부름",
       "missionTitle" : "심부름 미션",
       "starScore" : 3,
-      "createdAt" : "2023-11-28T16:02:27"
+      "createdAt" : "2023-11-28T16:11:23"
     } ],
     "pageable" : {
       "pageNumber" : 0,
@@ -8838,7 +8843,7 @@ Content-Length: 1142
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>
@@ -9206,7 +9211,7 @@ Content-Length: 1299
       "isBookmarked" : false
     } ]
   },
-  "serverDateTime" : "2023-11-28T16:02:26"
+  "serverDateTime" : "2023-11-28T16:11:22"
 }</code></pre>
 </div>
 </div>
@@ -9496,22 +9501,22 @@ Content-Length: 1245
   "status" : 200,
   "data" : {
     "content" : [ {
-      "id" : "0123adb4-75f0-4bc7-9a4d-508c97a06661",
+      "id" : "dc3fea1f-1974-4dc1-a7f4-d06b9af4d1a6",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-21T12:00:00"
     }, {
-      "id" : "f56be5ad-008f-4f88-856e-8a0ac31cbe73",
+      "id" : "8b94c210-ffb8-4136-8310-f745d9606c75",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-21T10:00:00"
     }, {
-      "id" : "729da4be-aab7-4e8a-bfd7-2ae4f1426271",
+      "id" : "a06d9051-dfb6-4d03-b4ef-a8f4cd2a9eb0",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-20T12:00:00"
     }, {
-      "id" : "d982721a-69a8-4f0b-965e-5db549cce1fc",
+      "id" : "1fa00524-052c-4c66-8f88-b53c54738301",
       "title" : "알림 제목",
       "content" : "알림 내용",
       "createdAt" : "2023-11-14T12:00:00"
@@ -9540,7 +9545,7 @@ Content-Length: 1245
     "last" : false,
     "empty" : false
   },
-  "serverDateTime" : "2023-11-28T16:02:25"
+  "serverDateTime" : "2023-11-28T16:11:21"
 }</code></pre>
 </div>
 </div>
@@ -9764,7 +9769,7 @@ Content-Length: 1245
 <h4 id="_http_request_39"><a class="link" href="#_http_request_39">HTTP Request</a></h4>
 <div class="listingblock">
 <div class="content">
-<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/alarms/cc5da4b7-8c6e-490e-a1d3-f30750080325 HTTP/1.1
+<pre class="highlightjs highlight nowrap"><code class="language-http hljs" data-lang="http">DELETE /api/v1/alarms/86170619-fcfb-46c9-9f24-33ba4a500299 HTTP/1.1
 Content-Type: application/json;charset=UTF-8
 Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJpZCI6MSwicm9sZSI6Ik1FTUJFUiIsImlhdCI6MTY5OTk0MDA5NiwiZXhwIjoxNzU5OTQwMDk2fQ.7xyZyQIzbkp-FLxNOLXpSI3Yg0CZ8tAJvlHrgATzZB4
 Host: localhost:8080</code></pre>
@@ -9819,7 +9824,7 @@ Content-Length: 81
 {
   "status" : 204,
   "data" : null,
-  "serverDateTime" : "2023-11-28T16:02:25"
+  "serverDateTime" : "2023-11-28T16:11:21"
 }</code></pre>
 </div>
 </div>
@@ -9946,7 +9951,7 @@ Content-Length: 137
     "missionId" : 1,
     "headCount" : 2
   },
-  "serverDateTime" : "2023-11-28T16:02:25"
+  "serverDateTime" : "2023-11-28T16:11:21"
 }</code></pre>
 </div>
 </div>
@@ -10081,7 +10086,7 @@ Content-Length: 840
     "headCount" : 2,
     "lastSentMessageTime" : "2023-11-12T12:00:00"
   } ],
-  "serverDateTime" : "2023-11-28T16:02:25"
+  "serverDateTime" : "2023-11-28T16:11:21"
 }</code></pre>
 </div>
 </div>
@@ -10272,7 +10277,7 @@ Content-Length: 409
     "message" : "안녕하세요! 미션 내용 확인하고자합니다!",
     "sentMessageTime" : "2023-11-26T19:27:00"
   } ],
-  "serverDateTime" : "2023-11-28T16:02:25"
+  "serverDateTime" : "2023-11-28T16:11:21"
 }</code></pre>
 </div>
 </div>
@@ -10418,7 +10423,7 @@ Content-Length: 134
     "userId" : 1,
     "missionId" : 1
   },
-  "serverDateTime" : "2023-11-28T16:02:25"
+  "serverDateTime" : "2023-11-28T16:11:21"
 }</code></pre>
 </div>
 </div>
@@ -10538,7 +10543,7 @@ Content-Length: 472
       } ]
     } ]
   } ],
-  "serverDateTime" : "2023-11-28T16:02:27"
+  "serverDateTime" : "2023-11-28T16:11:23"
 }</code></pre>
 </div>
 </div>

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/user/ProfileControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/user/ProfileControllerTest.java
@@ -50,7 +50,7 @@ class ProfileControllerTest extends RestDocsSupport {
         var userId = 1L;
 
         var userBasicInfoResponse = new ProfileCitizenResponse.UserBasicInfoForProfileCitizenResponse("이름", "MALE", LocalDate.of(1990, 1, 1));
-        var userImageResponse = new UserImageResponse("profile.jpg", "unique.jpg", "https://");
+        var userImageResponse = new UserImageResponse(1L, "profile.jpg", "unique.jpg", "https://");
         var heroScore = 60;
 
         var profileCitizenResponse = new ProfileCitizenResponse(userBasicInfoResponse, userImageResponse, heroScore);
@@ -94,6 +94,9 @@ class ProfileControllerTest extends RestDocsSupport {
                         .attributes(getDateFormat())
                         .description("태어난 날짜"),
                     fieldWithPath("data.image").type(JsonFieldType.OBJECT).description("프로필 이미지"),
+                    fieldWithPath("data.image.id").type(JsonFieldType.NUMBER)
+                        .optional()
+                        .description("이미지 아이디"),
                     fieldWithPath("data.image.originalName").type(JsonFieldType.STRING)
                         .optional()
                         .description("원본 이름"),
@@ -168,6 +171,9 @@ class ProfileControllerTest extends RestDocsSupport {
                         .optional()
                         .description("자기 소개"),
                     fieldWithPath("data.image").type(JsonFieldType.OBJECT).description("프로필 이미지"),
+                    fieldWithPath("data.image.id").type(JsonFieldType.NUMBER)
+                        .optional()
+                        .description("이미지 아이디"),
                     fieldWithPath("data.image.originalName")
                         .type(JsonFieldType.STRING)
                         .optional()
@@ -273,6 +279,9 @@ class ProfileControllerTest extends RestDocsSupport {
                     fieldWithPath("data.content[].image.originalName").type(JsonFieldType.STRING)
                         .description("이미지 원본 이름")
                         .optional(),
+                    fieldWithPath("data.content[].image.id").type(JsonFieldType.NUMBER)
+                        .optional()
+                        .description("이미지 아이디"),
                     fieldWithPath("data.content[].image.uniqueName").type(JsonFieldType.STRING)
                         .description("이미지 고유 이름")
                         .optional(),
@@ -394,7 +403,7 @@ class ProfileControllerTest extends RestDocsSupport {
     }
 
     private UserImageResponse createUserImageResponse() {
-        return new UserImageResponse("profile.jpg", "unique.jpg", "https://");
+        return new UserImageResponse(1L, "profile.jpg", "unique.jpg", "https://");
     }
 
     private UserFavoriteWorkingDayResponse createUserFavoriteWorkingDayResponse() {

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/user/UserControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/user/UserControllerTest.java
@@ -40,14 +40,13 @@ import static com.sixheroes.onedayherocommon.converter.DateTimeConverter.convert
 import static com.sixheroes.onedayherocommon.converter.DateTimeConverter.convertTimetoString;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.doNothing;
 import static org.springframework.restdocs.headers.HeaderDocumentation.headerWithName;
 import static org.springframework.restdocs.headers.HeaderDocumentation.requestHeaders;
 import static org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document;
-import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete;
 import static org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get;
 import static org.springframework.restdocs.payload.PayloadDocumentation.*;
-import static org.springframework.restdocs.request.RequestDocumentation.*;
+import static org.springframework.restdocs.request.RequestDocumentation.parameterWithName;
+import static org.springframework.restdocs.request.RequestDocumentation.queryParameters;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -192,8 +191,9 @@ class UserControllerTest extends RestDocsSupport {
         var userBasicInfoRequest = new UserBasicInfoRequest("이름", "MALE", LocalDate.of(1990, 1, 1), "자기 소개");
         var userFavoriteWorkingDayRequest = new UserFavoriteWorkingDayRequest(List.of("MON", "THU"), LocalTime.of(12, 0, 0), LocalTime.of(18, 0, 0));
         var userFavoriteRegions = List.of(1L, 2L);
-        var userUpadateRequest = new UserUpdateRequest(userBasicInfoRequest, userFavoriteWorkingDayRequest, userFavoriteRegions);
-        var userUpdateRequestToMultipartFile = createUserUpdateRequestToMultipartFile(objectMapper.writeValueAsString(userUpadateRequest));
+        var userImageId = 1L;
+        var userUpdateRequest = new UserUpdateRequest(userBasicInfoRequest, userImageId, userFavoriteWorkingDayRequest, userFavoriteRegions);
+        var userUpdateRequestToMultipartFile = createUserUpdateRequestToMultipartFile(objectMapper.writeValueAsString(userUpdateRequest));
 
         var userImage = createUserImage();
 
@@ -229,6 +229,9 @@ class UserControllerTest extends RestDocsSupport {
                     fieldWithPath("basicInfo.introduce")
                         .optional()
                         .description("자기 소개"),
+                    fieldWithPath("userImageId")
+                        .optional()
+                        .description("유저의 이미지 아이디"),
                     fieldWithPath("favoriteWorkingDay").type(JsonFieldType.OBJECT).description("희망 근무 정보"),
                     fieldWithPath("favoriteWorkingDay.favoriteDate")
                         .optional()
@@ -258,42 +261,6 @@ class UserControllerTest extends RestDocsSupport {
                     fieldWithPath("data").type(JsonFieldType.OBJECT)
                         .description("응답 데이터"),
                     fieldWithPath("data.id").type(JsonFieldType.NUMBER).description("유저 아이디")
-                )
-            ));
-    }
-
-    @DisplayName("유저는 프로필 이미지를 삭제할 수 있다.")
-    @Test
-    void deleteUserImage() throws Exception {
-        // given
-        var userImageId = 1L;
-
-        doNothing().when(userService).deleteUserImage(anyLong(), anyLong());
-
-        // when & then
-        mockMvc.perform(delete("/api/v1/me/user-images/{userImageId}", userImageId)
-            .header(HttpHeaders.AUTHORIZATION, getAccessToken())
-            .contentType(MediaType.APPLICATION_JSON))
-            .andDo(print())
-            .andExpect(status().isNoContent())
-            .andExpect(jsonPath("$.status").value(204))
-            .andExpect(jsonPath("$.serverDateTime").exists())
-            .andExpect(jsonPath("$.data").doesNotExist())
-            .andDo(document("user-image-delete",
-                requestHeaders(
-                    headerWithName(HttpHeaders.AUTHORIZATION).description("Authorization: Bearer 액세스토큰")
-                ),
-                pathParameters(
-                    parameterWithName("userImageId").description("유저 이미지 아이디")
-                ),
-                responseFields(
-                    fieldWithPath("status").type(JsonFieldType.NUMBER)
-                        .description("HTTP 응답 코드"),
-                    fieldWithPath("serverDateTime").type(JsonFieldType.STRING)
-                        .description("서버 응답 시간")
-                        .attributes(getDateTimeFormat()),
-                    fieldWithPath("data").type(JsonFieldType.NULL)
-                        .description("응답 데이터")
                 )
             ));
     }

--- a/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/user/UserControllerTest.java
+++ b/onedayhero-api/src/test/java/com/sixheroes/onedayheroapi/user/UserControllerTest.java
@@ -130,6 +130,7 @@ class UserControllerTest extends RestDocsSupport {
                         .optional()
                         .description("자기 소개"),
                     fieldWithPath("data.image").type(JsonFieldType.OBJECT).description("프로필 이미지"),
+                    fieldWithPath("data.image.id").type(JsonFieldType.NUMBER).description("프로필 이미지 아이디"),
                     fieldWithPath("data.image.originalName")
                         .type(JsonFieldType.STRING)
                         .optional()
@@ -909,7 +910,7 @@ class UserControllerTest extends RestDocsSupport {
     }
 
     private UserImageResponse createUserImageResponse() {
-        return new UserImageResponse("profile.jpg", "unique.jpg", "http://");
+        return new UserImageResponse(1L, "profile.jpg", "unique.jpg", "http://");
     }
 
     private UserFavoriteWorkingDayResponse createUserFavoriteWorkingDayResponse() {

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/UserService.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/UserService.java
@@ -36,7 +36,6 @@ public class UserService {
     private final UserReader userReader;
     private final UserRegionReader userRegionReader;
     private final RegionReader regionReader;
-    private final UserImageReader userImageReader;
 
     private final UserRegionRepository userRegionRepository;
     private final UserImageRepository userImageRepository;
@@ -87,24 +86,13 @@ public class UserService {
         // 변경된 유저 선호 지역 모두 넣기
         insertUserRegions(user, userServiceUpdateRequest);
 
+        // 기존 유저 이미지 삭제
+        deleteUserImage(user, userServiceUpdateRequest);
+
+        // 새로운 이미지 업로드
         uploadUserImage(s3ImageUploadServiceRequests, user);
 
         return UserUpdateResponse.from(user);
-    }
-
-    @Transactional
-    public void deleteUserImage(
-            Long userId,
-            Long userImageId
-    ) {
-        var userImage = userImageReader.findOne(userImageId);
-
-        userImage.validOwner(userId);
-
-        var s3ImageDeleteServiceRequest = s3ImageDeleteServiceRequestMapper.apply(userImage);
-        s3ImageDeleteService.deleteImages(List.of(s3ImageDeleteServiceRequest));
-
-        userImageRepository.delete(userImage);
     }
 
     @Transactional
@@ -148,6 +136,21 @@ public class UserService {
 
         var userRegions = userServiceUpdateRequest.toUserRegions(user);
         userRegionRepository.saveAll(userRegions);
+    }
+
+    private void deleteUserImage(
+        User user,
+        UserServiceUpdateRequest userServiceUpdateRequest
+    ) {
+        if (Objects.isNull(userServiceUpdateRequest.userImageId())) {
+            var userImages = user.getUserImages();
+            var s3ImageDeleteServiceRequests = userImages.stream()
+                .map(s3ImageDeleteServiceRequestMapper)
+                .toList();
+            s3ImageDeleteService.deleteImages(s3ImageDeleteServiceRequests);
+
+            userImageRepository.deleteAllInBatch(userImages);
+        }
     }
 
     private void uploadUserImage(

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/request/UserServiceUpdateRequest.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/request/UserServiceUpdateRequest.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 @Builder
 public record UserServiceUpdateRequest(
     UserBasicInfoServiceRequest userBasicInfo,
+    Long userImageId,
     UserFavoriteWorkingDayServiceRequest userFavoriteWorkingDay,
     List<Long> userFavoriteRegions
 ) {

--- a/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/response/UserImageResponse.java
+++ b/onedayhero-application/src/main/java/com/sixheroes/onedayheroapplication/user/response/UserImageResponse.java
@@ -7,6 +7,7 @@ import java.util.Objects;
 
 @Builder
 public record UserImageResponse(
+    Long id,
     String originalName,
     String uniqueName,
     String path
@@ -22,6 +23,7 @@ public record UserImageResponse(
         }
 
         return UserImageResponse.builder()
+            .id(userImage.getId())
             .originalName(userImage.getOriginalName())
             .uniqueName(userImage.getUniqueName())
             .path(userImage.getPath())


### PR DESCRIPTION
## 🖊️ 1. Changes

- 유저 프로필 수정 API에서 기존 이미지를 삭제 그리고 새로운 이미지를 추가하는 로직으로 변경했습니다.
- 유저 이미지 삭제 API는 제거하였습니다.
- SSE 통신에서 이벤트가 아닌 메시지로 전달하도록 바꿨습니다.

## 🖼️ 2. Screenshot

-

## ❗️ 3. Issues

1. 
2. 

## 😌 4. To Reviewer

-

## 🙌 6. Checklist
- [x] - 통합 테스트를 수행해보셨나요?
- [x] - 혹시 컨벤션에 맞지 않게 작성하지 않았나요?
- [x] - Change와 Issue, Reviewer를 알아보기 쉽게 작성하였나요?
